### PR TITLE
Update CI to use setup-java

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '8' ] #, '11', '17' ]
     name: Test using Java ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        java: [ '8', '11', '17' ]
+    name: Test using Java ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v2
-    - uses: olafurpg/setup-scala@v10
+    - name: Setup Java
+      uses: actions/setup-java@v2
+      with:
+          java-version: ${{ matrix.java }}
     - run: sbt +test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,6 @@ jobs:
     - name: Setup Java
       uses: actions/setup-java@v2
       with:
+          distribution: 'adopt'
           java-version: ${{ matrix.java }}
     - run: sbt +test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v10
+      - uses: actions/setup-java@v2
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '17'
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '17'
+          java-version: '8'
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/build.sbt
+++ b/build.sbt
@@ -40,9 +40,18 @@ inThisBuild(
     )
   )
 )
+val depSettings = Def.setting {
+  CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((3, _))  => Nil
+    case Some((2, 11)) => Seq("-target:jvm-1.8")
+    case Some((2, 12)) => Seq("-target:jvm-1.8", "-Xsource:3")
+    case Some((2, 13)) => Seq("-Xsource:3")
+    case _             => Nil
+  }
+}
 
 val commonSettings: Seq[Setting[_]] = Seq(
-  scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xsource:3")
+  scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature") ++ depSettings.value
 )
 
 lazy val root = (project in file("."))
@@ -88,8 +97,7 @@ lazy val testSuite = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .settings(commonSettings: _*)
   .settings(skipPublish: _*)
   .settings(
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-s", "-v"),
-    scalacOptions += "-target:jvm-1.8"
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-s", "-v")
   )
   .jvmSettings(
     name := "java.time testSuite on JVM",

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 val scala211 = "2.11.12"
 val scala212 = "2.12.15"
 val scala213 = "2.13.7"
-val scala300 = "3.0.2"
+val scala300 = "3.1.0"
 
 val versionsBase   = Seq(scala212, scala211, scala213)
 val versionsJVM    = versionsBase :+ scala300
@@ -70,8 +70,7 @@ lazy val sjavatime = crossProject(JSPlatform, NativePlatform)
     Test / test := {},
     Compile / packageBin / mappings ~= {
       _.filter(!_._2.endsWith(".class"))
-    },
-    sharedScala2or3Source
+    }
   )
   .jsSettings(
     crossScalaVersions := versionsJS
@@ -118,25 +117,6 @@ lazy val testSuite = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 lazy val testSuiteJS     = testSuite.js
 lazy val testSuiteNative = testSuite.native
 lazy val testSuiteJVM    = testSuite.jvm
-
-lazy val sharedScala2or3Source: Seq[Setting[_]] = Def.settings(
-  Compile / unmanagedSourceDirectories ++= {
-    val projectDir = baseDirectory.value.getParentFile()
-    sourceDir(projectDir, scalaVersion.value)
-  }
-)
-
-// For Scala 2/3 enums
-def sourceDir(projectDir: File, scalaVersion: String): Seq[File] = {
-  def versionDir(versionDir: String): File =
-    projectDir / "shared" / "src" / "main" / versionDir
-
-  CrossVersion.partialVersion(scalaVersion) match {
-    case Some((3, _)) => Seq(versionDir("scala-3"))
-    case Some((2, _)) => Seq(versionDir("scala-2"))
-    case _            => Seq() // unknown version
-  }
-}
 
 val skipPublish = Seq(
   // no artifacts in this project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 // versions
-val crossVer           = "1.0.0"
+val crossVer           = "1.1.0"
 val scalaJSVersion     = "1.7.1"
 val scalaNativeVersion = "0.4.1"
 
@@ -12,4 +12,8 @@ addSbtPlugin("org.scala-native"   % "sbt-scala-native"              % scalaNativ
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % crossVer)
 
 // includes sbt-dynver sbt-pgp sbt-sonatype sbt-git
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.9")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
+
+// Workaround until Scala.js 1.8.0 released
+// See https://github.com/scala-js/scala-js-js-envs/issues/12
+libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.2.1"

--- a/sjavatime/shared/src/main/scala-2/java/time/Month.scala
+++ b/sjavatime/shared/src/main/scala-2/java/time/Month.scala
@@ -94,7 +94,7 @@ object Month {
   private lazy val months = Seq(JANUARY, FEBRUARY, MARCH, APRIL, MAY, JUNE,
       JULY, AUGUST, SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER)
 
-  def values(): Array[Month] = months.toArray
+  def values: Array[Month] = months.toArray
 
   def valueOf(name: String): Month = months.find(_.name == name).getOrElse {
     throw new IllegalArgumentException(s"No such month: $name")

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/DateTimeTestUtil.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/DateTimeTestUtil.scala
@@ -3,10 +3,10 @@ package org.scalajs.testsuite.javalib.time
 import java.time.DateTimeException
 import java.time.temporal.{ChronoUnit, Temporal, UnsupportedTemporalTypeException}
 
-import org.junit.Assert._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 object DateTimeTestUtil {
-  import org.scalajs.testsuite.utils.AssertThrows._
 
   val dateBasedUnits = ChronoUnit.values.filter(_.isDateBased)
 
@@ -15,17 +15,16 @@ object DateTimeTestUtil {
   def testDateTime(actual: => Any)(expected: => Any): Unit = {
     try {
       val e = expected
-      //expectNoException(actual)
       assertEquals(e, actual)
     } catch {
       case _: UnsupportedTemporalTypeException =>
-        expectThrows(classOf[UnsupportedTemporalTypeException], actual)
+        assertThrows(classOf[UnsupportedTemporalTypeException], actual)
 
       case _: DateTimeException =>
-        expectThrows(classOf[DateTimeException], actual)
+        assertThrows(classOf[DateTimeException], actual)
 
       case _: ArithmeticException =>
-        expectThrows(classOf[ArithmeticException], actual)
+        assertThrows(classOf[ArithmeticException], actual)
     }
   }
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/DayOfWeekTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/DayOfWeekTest.scala
@@ -4,8 +4,8 @@ import java.time._
 import java.time.temporal.ChronoField
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.{assertEquals, assertArrayEquals}
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class DayOfWeekTest extends TemporalAccessorTest[DayOfWeek] {
   import DayOfWeek._
@@ -75,7 +75,7 @@ class DayOfWeekTest extends TemporalAccessorTest[DayOfWeek] {
     assertEquals(SATURDAY, valueOf("SATURDAY"))
     assertEquals(SUNDAY, valueOf("SUNDAY"))
 
-    expectThrows(classOf[IllegalArgumentException], valueOf(""))
+    assertThrows(classOf[IllegalArgumentException], valueOf(""))
   }
 
   @Test def test_of(): Unit = {
@@ -88,7 +88,7 @@ class DayOfWeekTest extends TemporalAccessorTest[DayOfWeek] {
     assertEquals(SUNDAY, of(7))
 
     for (n <- Seq(Int.MinValue, 0, 8, Int.MaxValue))
-      expectThrows(classOf[DateTimeException], of(n))
+      assertThrows(classOf[DateTimeException], of(n))
   }
 
   @Test def test_from(): Unit = {
@@ -97,7 +97,7 @@ class DayOfWeekTest extends TemporalAccessorTest[DayOfWeek] {
     for (d <- Seq(LocalDate.MIN, LocalDate.of(2012, 2, 29), LocalDate.MAX))
       assertEquals(d.getDayOfWeek, from(d))
 
-    expectThrows(classOf[DateTimeException], from(LocalTime.MIN))
-    expectThrows(classOf[DateTimeException], from(Month.JANUARY))
+    assertThrows(classOf[DateTimeException], from(LocalTime.MIN))
+    assertThrows(classOf[DateTimeException], from(Month.JANUARY))
   }
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/DurationTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/DurationTest.scala
@@ -4,8 +4,9 @@ import java.time._
 import java.time.temporal.{ChronoUnit, UnsupportedTemporalTypeException}
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 class DurationTest extends TemporalAmountTest[Duration] {
@@ -86,7 +87,7 @@ class DurationTest extends TemporalAmountTest[Duration] {
       d <- samples
       n <- args
     } {
-      expectThrows(classOf[DateTimeException], d.withNanos(n))
+      assertThrows(classOf[DateTimeException], d.withNanos(n))
     }
   }
 
@@ -102,8 +103,8 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(ofSeconds(2, 2), d1.plus(d1))
     assertEquals(ofSeconds(3), d1.plus(d2))
     assertEquals(ofSeconds(-1, 2), d1.plus(d3))
-    expectThrows(classOf[ArithmeticException], dmax.plus(oneNano))
-    expectThrows(classOf[ArithmeticException], dmin.plus(oneNano.negated))
+    assertThrows(classOf[ArithmeticException], dmax.plus(oneNano))
+    assertThrows(classOf[ArithmeticException], dmin.plus(oneNano.negated))
 
     val args = Seq(Long.MinValue, -100000000000000L, 1L, 0L, 1L,
         100000000000000L, Long.MaxValue)
@@ -125,7 +126,7 @@ class DurationTest extends TemporalAmountTest[Duration] {
       n <- args
       u <- illegalUnits
     } {
-      expectThrows(classOf[UnsupportedTemporalTypeException], d.plus(n, u))
+      assertThrows(classOf[UnsupportedTemporalTypeException], d.plus(n, u))
     }
   }
 
@@ -148,10 +149,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.plusDays(0))
     assertEquals(d3, dmin.plusDays(1))
 
-    expectThrows(classOf[ArithmeticException], d4.plusDays(1))
-    expectThrows(classOf[ArithmeticException], d2.plusDays(2))
-    expectThrows(classOf[ArithmeticException], d5.plusDays(-1))
-    expectThrows(classOf[ArithmeticException], d3.plusDays(-2))
+    assertThrows(classOf[ArithmeticException], d4.plusDays(1))
+    assertThrows(classOf[ArithmeticException], d2.plusDays(2))
+    assertThrows(classOf[ArithmeticException], d5.plusDays(-1))
+    assertThrows(classOf[ArithmeticException], d3.plusDays(-2))
   }
 
   @Test def test_plusHours(): Unit = {
@@ -173,10 +174,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.plusHours(0))
     assertEquals(d3, dmin.plusHours(1))
 
-    expectThrows(classOf[ArithmeticException], d4.plusHours(1))
-    expectThrows(classOf[ArithmeticException], d2.plusHours(2))
-    expectThrows(classOf[ArithmeticException], d5.plusHours(-1))
-    expectThrows(classOf[ArithmeticException], d3.plusHours(-2))
+    assertThrows(classOf[ArithmeticException], d4.plusHours(1))
+    assertThrows(classOf[ArithmeticException], d2.plusHours(2))
+    assertThrows(classOf[ArithmeticException], d5.plusHours(-1))
+    assertThrows(classOf[ArithmeticException], d3.plusHours(-2))
   }
 
   @Test def test_plusMinutes(): Unit = {
@@ -198,10 +199,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.plusMinutes(0))
     assertEquals(d3, dmin.plusMinutes(1))
 
-    expectThrows(classOf[ArithmeticException], d4.plusMinutes(1))
-    expectThrows(classOf[ArithmeticException], d2.plusMinutes(2))
-    expectThrows(classOf[ArithmeticException], d5.plusMinutes(-1))
-    expectThrows(classOf[ArithmeticException], d3.plusMinutes(-2))
+    assertThrows(classOf[ArithmeticException], d4.plusMinutes(1))
+    assertThrows(classOf[ArithmeticException], d2.plusMinutes(2))
+    assertThrows(classOf[ArithmeticException], d5.plusMinutes(-1))
+    assertThrows(classOf[ArithmeticException], d3.plusMinutes(-2))
   }
 
   @Test def test_plusSeconds(): Unit = {
@@ -223,10 +224,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.plusSeconds(0))
     assertEquals(d3, dmin.plusSeconds(1))
 
-    expectThrows(classOf[ArithmeticException], d4.plusSeconds(1))
-    expectThrows(classOf[ArithmeticException], d2.plusSeconds(2))
-    expectThrows(classOf[ArithmeticException], d5.plusSeconds(-1))
-    expectThrows(classOf[ArithmeticException], d3.plusSeconds(-2))
+    assertThrows(classOf[ArithmeticException], d4.plusSeconds(1))
+    assertThrows(classOf[ArithmeticException], d2.plusSeconds(2))
+    assertThrows(classOf[ArithmeticException], d5.plusSeconds(-1))
+    assertThrows(classOf[ArithmeticException], d3.plusSeconds(-2))
   }
 
   @Test def test_plusMillis(): Unit = {
@@ -248,10 +249,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.plusMillis(0))
     assertEquals(d3, dmin.plusMillis(1))
 
-    expectThrows(classOf[ArithmeticException], d4.plusMillis(1))
-    expectThrows(classOf[ArithmeticException], d2.plusMillis(2))
-    expectThrows(classOf[ArithmeticException], d5.plusMillis(-1))
-    expectThrows(classOf[ArithmeticException], d3.plusMillis(-2))
+    assertThrows(classOf[ArithmeticException], d4.plusMillis(1))
+    assertThrows(classOf[ArithmeticException], d2.plusMillis(2))
+    assertThrows(classOf[ArithmeticException], d5.plusMillis(-1))
+    assertThrows(classOf[ArithmeticException], d3.plusMillis(-2))
   }
 
   @Test def test_plusNanos(): Unit = {
@@ -271,10 +272,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.plusNanos(0))
     assertEquals(d3, dmin.plusNanos(1))
 
-    expectThrows(classOf[ArithmeticException], dmax.plusNanos(1))
-    expectThrows(classOf[ArithmeticException], d2.plusNanos(2))
-    expectThrows(classOf[ArithmeticException], dmin.plusNanos(-1))
-    expectThrows(classOf[ArithmeticException], d3.plusNanos(-2))
+    assertThrows(classOf[ArithmeticException], dmax.plusNanos(1))
+    assertThrows(classOf[ArithmeticException], d2.plusNanos(2))
+    assertThrows(classOf[ArithmeticException], dmin.plusNanos(-1))
+    assertThrows(classOf[ArithmeticException], d3.plusNanos(-2))
   }
 
   @Test def test_minus(): Unit = {
@@ -287,8 +288,8 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(d1.negated, ZERO.minus(d1))
     assertEquals(ofSeconds(-1, 2), d1.minus(d2))
     assertEquals(ofSeconds(3), d1.minus(d3))
-    expectThrows(classOf[ArithmeticException], dmax.minus(oneNano.negated))
-    expectThrows(classOf[ArithmeticException], dmin.minus(oneNano))
+    assertThrows(classOf[ArithmeticException], dmax.minus(oneNano.negated))
+    assertThrows(classOf[ArithmeticException], dmin.minus(oneNano))
 
     val args = Seq(Long.MinValue, -100000000000000L, 1L, 0L, 1L,
         100000000000000L, Long.MaxValue)
@@ -310,7 +311,7 @@ class DurationTest extends TemporalAmountTest[Duration] {
       n <- args
       u <- illegalUnits
     } {
-      expectThrows(classOf[UnsupportedTemporalTypeException], d.minus(n, u))
+      assertThrows(classOf[UnsupportedTemporalTypeException], d.minus(n, u))
     }
   }
 
@@ -333,10 +334,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.minusDays(0))
     assertEquals(d3, dmin.minusDays(-1))
 
-    expectThrows(classOf[ArithmeticException], d4.minusDays(-1))
-    expectThrows(classOf[ArithmeticException], d2.minusDays(-2))
-    expectThrows(classOf[ArithmeticException], d5.minusDays(1))
-    expectThrows(classOf[ArithmeticException], d3.minusDays(2))
+    assertThrows(classOf[ArithmeticException], d4.minusDays(-1))
+    assertThrows(classOf[ArithmeticException], d2.minusDays(-2))
+    assertThrows(classOf[ArithmeticException], d5.minusDays(1))
+    assertThrows(classOf[ArithmeticException], d3.minusDays(2))
   }
 
   @Test def test_minusHours(): Unit = {
@@ -358,10 +359,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.minusHours(0))
     assertEquals(d3, dmin.minusHours(-1))
 
-    expectThrows(classOf[ArithmeticException], d4.minusHours(-1))
-    expectThrows(classOf[ArithmeticException], d2.minusHours(-2))
-    expectThrows(classOf[ArithmeticException], d5.minusHours(1))
-    expectThrows(classOf[ArithmeticException], d3.minusHours(2))
+    assertThrows(classOf[ArithmeticException], d4.minusHours(-1))
+    assertThrows(classOf[ArithmeticException], d2.minusHours(-2))
+    assertThrows(classOf[ArithmeticException], d5.minusHours(1))
+    assertThrows(classOf[ArithmeticException], d3.minusHours(2))
   }
 
   @Test def test_minusMinutes(): Unit = {
@@ -383,10 +384,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.minusMinutes(0))
     assertEquals(d3, dmin.minusMinutes(-1))
 
-    expectThrows(classOf[ArithmeticException], d4.minusMinutes(-1))
-    expectThrows(classOf[ArithmeticException], d2.minusMinutes(-2))
-    expectThrows(classOf[ArithmeticException], d5.minusMinutes(1))
-    expectThrows(classOf[ArithmeticException], d3.minusMinutes(2))
+    assertThrows(classOf[ArithmeticException], d4.minusMinutes(-1))
+    assertThrows(classOf[ArithmeticException], d2.minusMinutes(-2))
+    assertThrows(classOf[ArithmeticException], d5.minusMinutes(1))
+    assertThrows(classOf[ArithmeticException], d3.minusMinutes(2))
   }
 
   @Test def test_minusSeconds(): Unit = {
@@ -408,10 +409,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.minusSeconds(0))
     assertEquals(d3, dmin.minusSeconds(-1))
 
-    expectThrows(classOf[ArithmeticException], d4.minusSeconds(-1))
-    expectThrows(classOf[ArithmeticException], d2.minusSeconds(-2))
-    expectThrows(classOf[ArithmeticException], d5.minusSeconds(1))
-    expectThrows(classOf[ArithmeticException], d3.minusSeconds(2))
+    assertThrows(classOf[ArithmeticException], d4.minusSeconds(-1))
+    assertThrows(classOf[ArithmeticException], d2.minusSeconds(-2))
+    assertThrows(classOf[ArithmeticException], d5.minusSeconds(1))
+    assertThrows(classOf[ArithmeticException], d3.minusSeconds(2))
   }
 
   @Test def test_minusMillis(): Unit = {
@@ -433,10 +434,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.minusMillis(0))
     assertEquals(d3, dmin.minusMillis(-1))
 
-    expectThrows(classOf[ArithmeticException], d4.minusMillis(-1))
-    expectThrows(classOf[ArithmeticException], d2.minusMillis(-2))
-    expectThrows(classOf[ArithmeticException], d5.minusMillis(1))
-    expectThrows(classOf[ArithmeticException], d3.minusMillis(2))
+    assertThrows(classOf[ArithmeticException], d4.minusMillis(-1))
+    assertThrows(classOf[ArithmeticException], d2.minusMillis(-2))
+    assertThrows(classOf[ArithmeticException], d5.minusMillis(1))
+    assertThrows(classOf[ArithmeticException], d3.minusMillis(2))
   }
 
   @Test def test_minusNanos(): Unit = {
@@ -456,10 +457,10 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmin, dmin.minusNanos(0))
     assertEquals(d3, dmin.minusNanos(-1))
 
-    expectThrows(classOf[ArithmeticException], dmax.minusNanos(-1))
-    expectThrows(classOf[ArithmeticException], d2.minusNanos(-2))
-    expectThrows(classOf[ArithmeticException], dmin.minusNanos(1))
-    expectThrows(classOf[ArithmeticException], d3.minusNanos(2))
+    assertThrows(classOf[ArithmeticException], dmax.minusNanos(-1))
+    assertThrows(classOf[ArithmeticException], d2.minusNanos(-2))
+    assertThrows(classOf[ArithmeticException], dmin.minusNanos(1))
+    assertThrows(classOf[ArithmeticException], d3.minusNanos(2))
   }
 
   @Test def test_multipliedBy(): Unit = {
@@ -485,11 +486,11 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(ofSeconds(1000000001), d2.multipliedBy(-1000000000))
     assertEquals(dmin.plusNanos(1), dmax.multipliedBy(-1))
 
-    expectThrows(classOf[ArithmeticException], dmin.multipliedBy(-1))
-    expectThrows(classOf[ArithmeticException], dmin.multipliedBy(2))
-    expectThrows(classOf[ArithmeticException], dmax.multipliedBy(2))
-    expectThrows(classOf[ArithmeticException], d1.multipliedBy(Long.MaxValue))
-    expectThrows(classOf[ArithmeticException], d1.multipliedBy(Long.MinValue))
+    assertThrows(classOf[ArithmeticException], dmin.multipliedBy(-1))
+    assertThrows(classOf[ArithmeticException], dmin.multipliedBy(2))
+    assertThrows(classOf[ArithmeticException], dmax.multipliedBy(2))
+    assertThrows(classOf[ArithmeticException], d1.multipliedBy(Long.MaxValue))
+    assertThrows(classOf[ArithmeticException], d1.multipliedBy(Long.MinValue))
   }
 
   @Test def test_dividedBy(): Unit = {
@@ -501,7 +502,7 @@ class DurationTest extends TemporalAmountTest[Duration] {
       assertEquals(d, d.dividedBy(1))
       testDateTime(d.dividedBy(-1))(d.negated)
     }
-    expectThrows(classOf[ArithmeticException], dmin.dividedBy(-1))
+    assertThrows(classOf[ArithmeticException], dmin.dividedBy(-1))
     for (n <- Seq(Long.MinValue, -1L, 1L, Long.MaxValue))
       assertEquals(ZERO, ZERO.dividedBy(n))
     assertEquals(ofSeconds(5, 50), d1.dividedBy(2))
@@ -539,9 +540,9 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(oneSecond.negated, dmin.plusNanos(2).dividedBy(Long.MaxValue))
     assertEquals(oneSecond, dmax.minusNanos(1).dividedBy(Long.MaxValue))
 
-    expectThrows(classOf[ArithmeticException], dmin.dividedBy(-1))
+    assertThrows(classOf[ArithmeticException], dmin.dividedBy(-1))
     for (d <- samples)
-      expectThrows(classOf[ArithmeticException], d.dividedBy(0))
+      assertThrows(classOf[ArithmeticException], d.dividedBy(0))
   }
 
   @Test def test_negated(): Unit = {
@@ -553,7 +554,7 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(ofSeconds(Long.MinValue, 1), dmax.negated)
     assertEquals(dmax, ofSeconds(Long.MinValue, 1).negated)
 
-    expectThrows(classOf[ArithmeticException], dmin.negated)
+    assertThrows(classOf[ArithmeticException], dmin.negated)
   }
 
   @Test def test_abs(): Unit = {
@@ -565,7 +566,7 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmax, dmax.abs)
     assertEquals(dmax, ofSeconds(Long.MinValue, 1).abs)
 
-    expectThrows(classOf[ArithmeticException], dmin.abs)
+    assertThrows(classOf[ArithmeticException], dmin.abs)
   }
 
   @Test def test_addTo(): Unit = {
@@ -577,8 +578,8 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmax.addTo(t), LocalTime.of(3, 30, 7, 999999999))
     assertEquals(ZERO.addTo(d), d)
 
-    expectThrows(classOf[UnsupportedTemporalTypeException], oneNano.addTo(d))
-    expectThrows(classOf[UnsupportedTemporalTypeException], oneSecond.addTo(d))
+    assertThrows(classOf[UnsupportedTemporalTypeException], oneNano.addTo(d))
+    assertThrows(classOf[UnsupportedTemporalTypeException], oneSecond.addTo(d))
   }
 
   @Test def test_subtractFrom(): Unit = {
@@ -590,8 +591,8 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(dmax.subtractFrom(t), LocalTime.of(20, 29, 52, 1))
     assertEquals(ZERO.subtractFrom(d), d)
 
-    expectThrows(classOf[UnsupportedTemporalTypeException], oneNano.subtractFrom(d))
-    expectThrows(classOf[UnsupportedTemporalTypeException], oneSecond.subtractFrom(d))
+    assertThrows(classOf[UnsupportedTemporalTypeException], oneNano.subtractFrom(d))
+    assertThrows(classOf[UnsupportedTemporalTypeException], oneSecond.subtractFrom(d))
   }
 
   @Test def test_toDays(): Unit = {
@@ -657,12 +658,12 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(9223372036854775807L,
         ofSeconds(9223372036854775L, 807999999).toMillis)
 
-    expectThrows(classOf[ArithmeticException], dmin.toMillis)
-    expectThrows(classOf[ArithmeticException], dmax.toMillis)
+    assertThrows(classOf[ArithmeticException], dmin.toMillis)
+    assertThrows(classOf[ArithmeticException], dmax.toMillis)
     // this could yield a valid long, but the reference implementation throws
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException],
         ofSeconds(-9223372036854775L, -1).toMillis)
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException],
         ofSeconds(9223372036854775L, 808000000).toMillis)
   }
 
@@ -677,12 +678,12 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(Int.MaxValue.toLong, ofNanos(Int.MaxValue).toNanos)
     assertEquals(Long.MaxValue, ofSeconds(9223372036L, 854775807).toNanos)
 
-    expectThrows(classOf[ArithmeticException], dmin.toNanos)
-    expectThrows(classOf[ArithmeticException], dmax.toNanos)
+    assertThrows(classOf[ArithmeticException], dmin.toNanos)
+    assertThrows(classOf[ArithmeticException], dmax.toNanos)
     // this should yield a valid long, but the reference implementation throws
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException],
         ofSeconds(-9223372036L, -1).toNanos)
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException],
         ofSeconds(9223372036L, 854775808).toNanos)
   }
 
@@ -746,8 +747,8 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(ofSeconds(86400), ofDays(1))
     assertEquals(ofSeconds(maxSecs), ofDays(maxDays))
 
-    expectThrows(classOf[ArithmeticException], ofDays(-maxDays - 1))
-    expectThrows(classOf[ArithmeticException], ofDays(maxDays + 1))
+    assertThrows(classOf[ArithmeticException], ofDays(-maxDays - 1))
+    assertThrows(classOf[ArithmeticException], ofDays(maxDays + 1))
   }
 
   @Test def test_ofHours(): Unit = {
@@ -760,8 +761,8 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(ofSeconds(3600), ofHours(1))
     assertEquals(ofSeconds(maxSecs), ofHours(maxHrs))
 
-    expectThrows(classOf[ArithmeticException], ofHours(-maxHrs - 1))
-    expectThrows(classOf[ArithmeticException], ofHours(maxHrs + 1))
+    assertThrows(classOf[ArithmeticException], ofHours(-maxHrs - 1))
+    assertThrows(classOf[ArithmeticException], ofHours(maxHrs + 1))
   }
 
   @Test def test_ofMinutes(): Unit = {
@@ -774,8 +775,8 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(ofSeconds(60), ofMinutes(1))
     assertEquals(ofSeconds(maxSecs), ofMinutes(maxMins))
 
-    expectThrows(classOf[ArithmeticException], ofMinutes(-maxMins - 1))
-    expectThrows(classOf[ArithmeticException], ofMinutes(maxMins + 1))
+    assertThrows(classOf[ArithmeticException], ofMinutes(-maxMins - 1))
+    assertThrows(classOf[ArithmeticException], ofMinutes(maxMins + 1))
   }
 
   @Test def test_ofSeconds(): Unit = {
@@ -788,8 +789,8 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(ofSeconds(1), ofSeconds(1, 0))
     assertEquals(ofSeconds(9, 999999999), ofSeconds(10, -1))
 
-    expectThrows(classOf[ArithmeticException], ofSeconds(Long.MinValue, -1))
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException], ofSeconds(Long.MinValue, -1))
+    assertThrows(classOf[ArithmeticException],
         ofSeconds(Long.MaxValue, 1000000000))
   }
 
@@ -832,24 +833,24 @@ class DurationTest extends TemporalAmountTest[Duration] {
         of(Long.MaxValue, MICROS))
 
     for (s <- Seq(-1, 1)) {
-      expectThrows(classOf[ArithmeticException], of(106751991167301L * s, DAYS))
-      expectThrows(classOf[ArithmeticException],
+      assertThrows(classOf[ArithmeticException], of(106751991167301L * s, DAYS))
+      assertThrows(classOf[ArithmeticException],
           of(213503982334602L * s, HALF_DAYS))
-      expectThrows(classOf[ArithmeticException],
+      assertThrows(classOf[ArithmeticException],
           of(2562047788015216L * s, HOURS))
-      expectThrows(classOf[ArithmeticException],
+      assertThrows(classOf[ArithmeticException],
           of(153722867280912931L * s, MINUTES))
     }
 
     for (n <- Seq(-1L, 0L, 1L)) {
-      expectThrows(classOf[UnsupportedTemporalTypeException], of(n, WEEKS))
-      expectThrows(classOf[UnsupportedTemporalTypeException], of(n, MONTHS))
-      expectThrows(classOf[UnsupportedTemporalTypeException], of(n, YEARS))
-      expectThrows(classOf[UnsupportedTemporalTypeException], of(n, DECADES))
-      expectThrows(classOf[UnsupportedTemporalTypeException], of(n, CENTURIES))
-      expectThrows(classOf[UnsupportedTemporalTypeException], of(n, MILLENNIA))
-      expectThrows(classOf[UnsupportedTemporalTypeException], of(n, ERAS))
-      expectThrows(classOf[UnsupportedTemporalTypeException], of(n, FOREVER))
+      assertThrows(classOf[UnsupportedTemporalTypeException], of(n, WEEKS))
+      assertThrows(classOf[UnsupportedTemporalTypeException], of(n, MONTHS))
+      assertThrows(classOf[UnsupportedTemporalTypeException], of(n, YEARS))
+      assertThrows(classOf[UnsupportedTemporalTypeException], of(n, DECADES))
+      assertThrows(classOf[UnsupportedTemporalTypeException], of(n, CENTURIES))
+      assertThrows(classOf[UnsupportedTemporalTypeException], of(n, MILLENNIA))
+      assertThrows(classOf[UnsupportedTemporalTypeException], of(n, ERAS))
+      assertThrows(classOf[UnsupportedTemporalTypeException], of(n, FOREVER))
     }
   }
 
@@ -858,7 +859,7 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(ZERO, from(ZERO))
     assertEquals(dmax, from(dmax))
 
-    expectThrows(classOf[UnsupportedTemporalTypeException], from(Period.ZERO))
+    assertThrows(classOf[UnsupportedTemporalTypeException], from(Period.ZERO))
   }
 
   @Test def test_between(): Unit = {
@@ -868,9 +869,9 @@ class DurationTest extends TemporalAmountTest[Duration] {
     assertEquals(ofNanos(86399999999999L), between(MIN, MAX))
     assertEquals(ofNanos(1), between(MIN, LocalTime.of(0, 0, 0, 1)))
 
-    expectThrows(classOf[DateTimeException],
+    assertThrows(classOf[DateTimeException],
         between(MIN, LocalDate.of(2012, 2, 29)))
-    expectThrows(classOf[DateTimeException],
+    assertThrows(classOf[DateTimeException],
         between(LocalDate.of(2012, 2, 29), LocalDate.of(2012, 3, 1)))
   }
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/InstantTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/InstantTest.scala
@@ -5,8 +5,8 @@ import java.time.format.DateTimeParseException
 import java.time.temporal.{UnsupportedTemporalTypeException, ChronoUnit, ChronoField}
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /** Created by alonsodomin on 26/12/2015. */
 class InstantTest extends TemporalTest[Instant] {
@@ -83,13 +83,13 @@ class InstantTest extends TemporalTest[Instant] {
         testDateTime(i.`with`(INSTANT_SECONDS, value).getLong(INSTANT_SECONDS))(value)
 
       for (n <- Seq(Long.MinValue, -1L, 1000000000L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], i.`with`(NANO_OF_SECOND, n))
+        assertThrows(classOf[DateTimeException], i.`with`(NANO_OF_SECOND, n))
       for (n <- Seq(Long.MinValue, -1L, 1000000L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], i.`with`(MICRO_OF_SECOND, n))
+        assertThrows(classOf[DateTimeException], i.`with`(MICRO_OF_SECOND, n))
       for (n <- Seq(Long.MinValue, -1L, 1000L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], i.`with`(MILLI_OF_SECOND, n))
+        assertThrows(classOf[DateTimeException], i.`with`(MILLI_OF_SECOND, n))
       for (n <- Seq(Long.MinValue, -31557014167219201L, 31557014167219201L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], i.`with`(INSTANT_SECONDS, n))
+        assertThrows(classOf[DateTimeException], i.`with`(INSTANT_SECONDS, n))
     }
   }
 
@@ -123,7 +123,7 @@ class InstantTest extends TemporalTest[Instant] {
     assertEquals(Instant.ofEpochSecond(-83827872000L), someNegativeInstant.truncatedTo(DAYS))
 
     for (i <- samples;u <- dateBasedUnits.filter(_ != DAYS))
-      expectThrows(classOf[UnsupportedTemporalTypeException], i.truncatedTo(u))
+      assertThrows(classOf[UnsupportedTemporalTypeException], i.truncatedTo(u))
   }
 
   @Test def plus(): Unit = {
@@ -137,7 +137,7 @@ class InstantTest extends TemporalTest[Instant] {
         if (!(i == Instant.MIN && n < 0) && !(i == Instant.MAX && n > 0))
           assertEquals(i.plusNanos(u.getDuration.toNanos * n), i.plus(n, u))
         else if ((i == Instant.MIN && n < 0) && (i == Instant.MAX && n > 0))
-          expectThrows(classOf[DateTimeException], i.plus(n, u))
+          assertThrows(classOf[DateTimeException], i.plus(n, u))
       }
     }
   }
@@ -150,10 +150,10 @@ class InstantTest extends TemporalTest[Instant] {
     assertEquals(Instant.ofEpochSecond(-1), Instant.EPOCH.plusSeconds(-1))
 
     assertEquals(Instant.ofEpochSecond(-31557014167219199L), Instant.MIN.plusSeconds(1))
-    expectThrows(classOf[DateTimeException], Instant.MIN.plusSeconds(-1))
+    assertThrows(classOf[DateTimeException], Instant.MIN.plusSeconds(-1))
     assertEquals(Instant.EPOCH, Instant.MIN.plusSeconds(31557014167219200L))
 
-    expectThrows(classOf[DateTimeException], Instant.MAX.plusSeconds(1))
+    assertThrows(classOf[DateTimeException], Instant.MAX.plusSeconds(1))
     assertEquals(Instant.ofEpochSecond(31556889864403198L, 999999999), Instant.MAX.plusSeconds(-1))
     assertEquals(Instant.ofEpochSecond(0, 999999999), Instant.MAX.plusSeconds(-31556889864403199L))
 
@@ -175,9 +175,9 @@ class InstantTest extends TemporalTest[Instant] {
         Instant.MIN.plusMillis(1))
     assertEquals(Instant.ofEpochSecond(-31557014167219199L, 0),
         Instant.MIN.plusMillis(1000))
-    expectThrows(classOf[DateTimeException], Instant.MIN.plusMillis(-1))
+    assertThrows(classOf[DateTimeException], Instant.MIN.plusMillis(-1))
 
-    expectThrows(classOf[DateTimeException], Instant.MAX.plusMillis(1))
+    assertThrows(classOf[DateTimeException], Instant.MAX.plusMillis(1))
     assertEquals(Instant.ofEpochSecond(31556889864403199L, 998999999),
         Instant.MAX.plusMillis(-1))
     assertEquals(Instant.ofEpochSecond(31556889864403198L, 999999999),
@@ -201,9 +201,9 @@ class InstantTest extends TemporalTest[Instant] {
         Instant.MIN.plusNanos(1))
     assertEquals(Instant.ofEpochSecond(-31557014167219199L, 0),
         Instant.MIN.plusNanos(1000000000))
-    expectThrows(classOf[DateTimeException], Instant.MIN.plusNanos(-1))
+    assertThrows(classOf[DateTimeException], Instant.MIN.plusNanos(-1))
 
-    expectThrows(classOf[DateTimeException], Instant.MAX.plusMillis(1))
+    assertThrows(classOf[DateTimeException], Instant.MAX.plusMillis(1))
     assertEquals(Instant.ofEpochSecond(31556889864403199L, 999999998),
         Instant.MAX.plusNanos(-1))
     assertEquals(Instant.ofEpochSecond(31556889864403198L, 999999999),
@@ -223,12 +223,12 @@ class InstantTest extends TemporalTest[Instant] {
     assertEquals(Instant.ofEpochSecond(-1), Instant.EPOCH.minusSeconds(1))
     assertEquals(Instant.ofEpochSecond(1), Instant.EPOCH.minusSeconds(-1))
 
-    expectThrows(classOf[DateTimeException], Instant.MIN.minusSeconds(1))
+    assertThrows(classOf[DateTimeException], Instant.MIN.minusSeconds(1))
     assertEquals(Instant.ofEpochSecond(-31557014167219199L), Instant.MIN.minusSeconds(-1))
     assertEquals(Instant.EPOCH, Instant.MIN.minusSeconds(-31557014167219200L))
 
     assertEquals(Instant.ofEpochSecond(31556889864403198L, 999999999), Instant.MAX.minusSeconds(1))
-    expectThrows(classOf[DateTimeException], Instant.MAX.minusSeconds(-1))
+    assertThrows(classOf[DateTimeException], Instant.MAX.minusSeconds(-1))
     assertEquals(Instant.ofEpochSecond(0, 999999999), Instant.MAX.minusSeconds(31556889864403199L))
 
     assertEquals(Instant.ofEpochSecond(928392982L, 942000000), somePositiveInstant.minusSeconds(1))
@@ -245,7 +245,7 @@ class InstantTest extends TemporalTest[Instant] {
     assertEquals(Instant.ofEpochMilli(-1), Instant.EPOCH.minusMillis(1))
     assertEquals(Instant.ofEpochMilli(1), Instant.EPOCH.minusMillis(-1))
 
-    expectThrows(classOf[DateTimeException], Instant.MIN.minusMillis(1))
+    assertThrows(classOf[DateTimeException], Instant.MIN.minusMillis(1))
     assertEquals(Instant.ofEpochSecond(-31557014167219200L, 1000000),
         Instant.MIN.minusMillis(-1))
     assertEquals(Instant.ofEpochSecond(-31557014167219199L, 0),
@@ -255,7 +255,7 @@ class InstantTest extends TemporalTest[Instant] {
         Instant.MAX.minusMillis(1))
     assertEquals(Instant.ofEpochSecond(31556889864403198L, 999999999),
         Instant.MAX.minusMillis(1000))
-    expectThrows(classOf[DateTimeException], Instant.MAX.minusMillis(-1))
+    assertThrows(classOf[DateTimeException], Instant.MAX.minusMillis(-1))
 
     assertEquals(Instant.ofEpochSecond(928392983L, 941000000), somePositiveInstant.minusMillis(1))
     assertEquals(Instant.ofEpochSecond(928392983L, 943000000), somePositiveInstant.minusMillis(-1))
@@ -271,7 +271,7 @@ class InstantTest extends TemporalTest[Instant] {
     assertEquals(Instant.ofEpochSecond(-1, 999999999), Instant.EPOCH.minusNanos(1))
     assertEquals(Instant.ofEpochSecond(0, 1), Instant.EPOCH.minusNanos(-1))
 
-    expectThrows(classOf[DateTimeException], Instant.MIN.minusNanos(1))
+    assertThrows(classOf[DateTimeException], Instant.MIN.minusNanos(1))
     assertEquals(Instant.ofEpochSecond(-31557014167219200L, 1),
         Instant.MIN.minusNanos(-1))
     assertEquals(Instant.ofEpochSecond(-31557014167219199L, 0),
@@ -281,7 +281,7 @@ class InstantTest extends TemporalTest[Instant] {
         Instant.MAX.minusNanos(1))
     assertEquals(Instant.ofEpochSecond(31556889864403198L, 999999999),
         Instant.MAX.minusNanos(1000000000))
-    expectThrows(classOf[DateTimeException], Instant.MAX.minusNanos(-1))
+    assertThrows(classOf[DateTimeException], Instant.MAX.minusNanos(-1))
 
     assertEquals(Instant.ofEpochSecond(928392983L, 941999999), somePositiveInstant.minusNanos(1))
     assertEquals(Instant.ofEpochSecond(928392983L, 942000001), somePositiveInstant.minusNanos(-1))
@@ -302,14 +302,14 @@ class InstantTest extends TemporalTest[Instant] {
       i <- samples
       date <- Seq(LocalDate.MIN, LocalDate.MAX)
     } {
-      expectThrows(classOf[DateTimeException], i.adjustInto(date))
+      assertThrows(classOf[DateTimeException], i.adjustInto(date))
     }
   }
 
   @Test def until(): Unit = {
-    expectThrows(classOf[ArithmeticException], Instant.MIN.until(Instant.MAX, NANOS))
-    expectThrows(classOf[ArithmeticException], Instant.MIN.until(Instant.MAX, MICROS))
-    expectThrows(classOf[ArithmeticException], Instant.MIN.until(Instant.MAX, MILLIS))
+    assertThrows(classOf[ArithmeticException], Instant.MIN.until(Instant.MAX, NANOS))
+    assertThrows(classOf[ArithmeticException], Instant.MIN.until(Instant.MAX, MICROS))
+    assertThrows(classOf[ArithmeticException], Instant.MIN.until(Instant.MAX, MILLIS))
 
     assertEquals(31557014167219200L, Instant.MIN.until(Instant.EPOCH, SECONDS))
     assertEquals(525950236120320L, Instant.MIN.until(Instant.EPOCH, MINUTES))
@@ -398,7 +398,7 @@ class InstantTest extends TemporalTest[Instant] {
     assertEquals(Instant.MIN, Instant.ofEpochSecond(-31557014167219200L, 0))
     assertEquals(Instant.MAX, Instant.ofEpochSecond(31556889864403199L, 999999999))
 
-    expectThrows(classOf[DateTimeException], Instant.ofEpochSecond(-31557014167219200L, Long.MinValue))
+    assertThrows(classOf[DateTimeException], Instant.ofEpochSecond(-31557014167219200L, Long.MinValue))
 
     val limits = Seq(-31557014167219200L, 31557014167219200L)
     val invalidNanos = Seq(Long.MinValue, -1L, 1000000000L, Long.MaxValue)
@@ -407,7 +407,7 @@ class InstantTest extends TemporalTest[Instant] {
       case (a, b) => ((a < 0) && (b < 0)) || ((a > 0) && (b > 0))
     }
     for ((s, n) <- invalidPairs)
-      expectThrows(classOf[DateTimeException], Instant.ofEpochSecond(s, n))
+      assertThrows(classOf[DateTimeException], Instant.ofEpochSecond(s, n))
   }
 
   @Test def ofEpochMilli(): Unit = {
@@ -419,13 +419,13 @@ class InstantTest extends TemporalTest[Instant] {
       assertEquals(i, Instant.from(i))
 
     val aTime = LocalTime.ofNanoOfDay(98392983293L)
-    expectThrows(classOf[DateTimeException], Instant.from(aTime))
+    assertThrows(classOf[DateTimeException], Instant.from(aTime))
 
     val aDate = LocalDate.ofEpochDay(392889321L)
-    expectThrows(classOf[DateTimeException], Instant.from(aDate))
+    assertThrows(classOf[DateTimeException], Instant.from(aDate))
 
     val aYear = Year.of(329)
-    expectThrows(classOf[DateTimeException], Instant.from(aYear))
+    assertThrows(classOf[DateTimeException], Instant.from(aYear))
   }
 
   @Test def parse(): Unit = {
@@ -445,14 +445,14 @@ class InstantTest extends TemporalTest[Instant] {
     val charSequence: CharSequence = "1999-06-03T06:56:23.942Z"
     assertEquals(somePositiveInstant, Instant.parse(charSequence))
 
-    expectThrows(classOf[DateTimeParseException], Instant.parse("+1000000001-12-31T23:59:59.999999999Z"))
-    expectThrows(classOf[DateTimeParseException], Instant.parse("-0687-99-07T23:38:33.088936253Z"))
-    expectThrows(classOf[DateTimeParseException], Instant.parse("-ABCD-08-07T23:38:33.088936253Z"))
-    expectThrows(classOf[DateTimeParseException], Instant.parse("1999-06-03T13:56:90.942Z"))
-    expectThrows(classOf[DateTimeParseException], Instant.parse("1999-06-03T13:65:23.942Z"))
-    expectThrows(classOf[DateTimeParseException], Instant.parse("1999-06-03T25:56:23.942Z"))
-    expectThrows(classOf[DateTimeParseException], Instant.parse("1999-06-99T13:56:23.942Z"))
-    expectThrows(classOf[DateTimeParseException], Instant.parse("1999-99-03T13:56:23.942Z"))
+    assertThrows(classOf[DateTimeParseException], Instant.parse("+1000000001-12-31T23:59:59.999999999Z"))
+    assertThrows(classOf[DateTimeParseException], Instant.parse("-0687-99-07T23:38:33.088936253Z"))
+    assertThrows(classOf[DateTimeParseException], Instant.parse("-ABCD-08-07T23:38:33.088936253Z"))
+    assertThrows(classOf[DateTimeParseException], Instant.parse("1999-06-03T13:56:90.942Z"))
+    assertThrows(classOf[DateTimeParseException], Instant.parse("1999-06-03T13:65:23.942Z"))
+    assertThrows(classOf[DateTimeParseException], Instant.parse("1999-06-03T25:56:23.942Z"))
+    assertThrows(classOf[DateTimeParseException], Instant.parse("1999-06-99T13:56:23.942Z"))
+    assertThrows(classOf[DateTimeParseException], Instant.parse("1999-99-03T13:56:23.942Z"))
   }
 
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/LocalDateTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/LocalDateTest.scala
@@ -6,8 +6,8 @@ import java.time.format.DateTimeParseException
 import java.time.temporal._
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class LocalDateTest extends TemporalTest[LocalDate] {
 
@@ -233,50 +233,50 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(someDate.`with`(ERA, 1))(someDate)
     testDateTime(leapDate.`with`(ERA, 0))(of(-2011, 2, 28))
 
-    expectThrows(classOf[DateTimeException], MAX.`with`(DAY_OF_WEEK, 6))
-    expectThrows(classOf[DateTimeException],
+    assertThrows(classOf[DateTimeException], MAX.`with`(DAY_OF_WEEK, 6))
+    assertThrows(classOf[DateTimeException],
         MAX.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, 4))
-    expectThrows(classOf[DateTimeException],
+    assertThrows(classOf[DateTimeException],
         MAX.`with`(ALIGNED_DAY_OF_WEEK_IN_YEAR, 2))
-    expectThrows(classOf[DateTimeException], someDate.`with`(DAY_OF_MONTH, 29))
-    expectThrows(classOf[DateTimeException], leapDate.`with`(DAY_OF_MONTH, 30))
-    expectThrows(classOf[DateTimeException], someDate.`with`(DAY_OF_YEAR, 366))
-    expectThrows(classOf[DateTimeException],
+    assertThrows(classOf[DateTimeException], someDate.`with`(DAY_OF_MONTH, 29))
+    assertThrows(classOf[DateTimeException], leapDate.`with`(DAY_OF_MONTH, 30))
+    assertThrows(classOf[DateTimeException], someDate.`with`(DAY_OF_YEAR, 366))
+    assertThrows(classOf[DateTimeException],
         someDate.`with`(YEAR_OF_ERA, 1000000000))
-    expectThrows(classOf[DateTimeException], MIN.`with`(ERA, 1))
+    assertThrows(classOf[DateTimeException], MIN.`with`(ERA, 1))
 
     for (d <- samples) {
       for (n <- Seq(Long.MinValue, 0L, 8L, Long.MaxValue)) {
-        expectThrows(classOf[DateTimeException], d.`with`(DAY_OF_WEEK, n))
-        expectThrows(classOf[DateTimeException],
+        assertThrows(classOf[DateTimeException], d.`with`(DAY_OF_WEEK, n))
+        assertThrows(classOf[DateTimeException],
             d.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, n))
-        expectThrows(classOf[DateTimeException],
+        assertThrows(classOf[DateTimeException],
             d.`with`(ALIGNED_DAY_OF_WEEK_IN_YEAR, n))
       }
       for (n <- Seq(Long.MinValue, 0L, 32L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], d.`with`(DAY_OF_MONTH, n))
+        assertThrows(classOf[DateTimeException], d.`with`(DAY_OF_MONTH, n))
       for (n <- Seq(Long.MinValue, 0L, 367L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], d.`with`(DAY_OF_YEAR, n))
+        assertThrows(classOf[DateTimeException], d.`with`(DAY_OF_YEAR, n))
       for (n <- Seq(Long.MinValue, -365243219163L, 365241780472L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], d.`with`(EPOCH_DAY, n))
+        assertThrows(classOf[DateTimeException], d.`with`(EPOCH_DAY, n))
       for (n <- Seq(Long.MinValue, 0L, 6L, Long.MaxValue)) {
-        expectThrows(classOf[DateTimeException],
+        assertThrows(classOf[DateTimeException],
             d.`with`(ALIGNED_WEEK_OF_MONTH, n))
       }
       for (n <- Seq(Long.MinValue, 0L, 54L, Long.MaxValue)) {
-        expectThrows(classOf[DateTimeException],
+        assertThrows(classOf[DateTimeException],
             d.`with`(ALIGNED_WEEK_OF_YEAR, n))
       }
       for (n <- Seq(Long.MinValue, 0L, 13L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], d.`with`(MONTH_OF_YEAR, n))
+        assertThrows(classOf[DateTimeException], d.`with`(MONTH_OF_YEAR, n))
       for (n <- Seq(Long.MinValue, -11999999989L, 12000000000L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], d.`with`(PROLEPTIC_MONTH, n))
+        assertThrows(classOf[DateTimeException], d.`with`(PROLEPTIC_MONTH, n))
       for (n <- Seq(Long.MinValue, 0L, 1000000001L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], d.`with`(YEAR_OF_ERA, n))
+        assertThrows(classOf[DateTimeException], d.`with`(YEAR_OF_ERA, n))
       for (n <- Seq(Long.MinValue, -1000000000L, 1000000000L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], d.`with`(YEAR, n))
+        assertThrows(classOf[DateTimeException], d.`with`(YEAR, n))
       for (n <- Seq(Long.MinValue, -1L, 2L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], d.`with`(ERA, n))
+        assertThrows(classOf[DateTimeException], d.`with`(ERA, n))
     }
   }
 
@@ -291,7 +291,7 @@ class LocalDateTest extends TemporalTest[LocalDate] {
       d <- samples
       n <- years
     } {
-      expectThrows(classOf[DateTimeException], d.withYear(n))
+      assertThrows(classOf[DateTimeException], d.withYear(n))
     }
   }
 
@@ -306,7 +306,7 @@ class LocalDateTest extends TemporalTest[LocalDate] {
       d <- samples
       n <- months
     } {
-      expectThrows(classOf[DateTimeException], d.withMonth(n))
+      assertThrows(classOf[DateTimeException], d.withMonth(n))
     }
   }
 
@@ -314,15 +314,15 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(someDate.withDayOfMonth(1))(of(2011, 2, 1))
     testDateTime(leapDate.withDayOfMonth(28))(of(2012, 2, 28))
 
-    expectThrows(classOf[DateTimeException], someDate.withDayOfMonth(29))
-    expectThrows(classOf[DateTimeException], leapDate.withDayOfMonth(30))
-    expectThrows(classOf[DateTimeException], of(0, 4, 30).withDayOfMonth(31))
+    assertThrows(classOf[DateTimeException], someDate.withDayOfMonth(29))
+    assertThrows(classOf[DateTimeException], leapDate.withDayOfMonth(30))
+    assertThrows(classOf[DateTimeException], of(0, 4, 30).withDayOfMonth(31))
     val days = Seq(Int.MinValue, 0, 32, Int.MaxValue)
     for {
       d <- samples
       n <- days
     } {
-      expectThrows(classOf[DateTimeException], d.withDayOfMonth(n))
+      assertThrows(classOf[DateTimeException], d.withDayOfMonth(n))
     }
   }
 
@@ -331,13 +331,13 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(someDate.withDayOfYear(365))(of(2011, 12, 31))
     testDateTime(leapDate.withDayOfYear(366))(of(2012, 12, 31))
 
-    expectThrows(classOf[DateTimeException], someDate.withDayOfYear(366))
+    assertThrows(classOf[DateTimeException], someDate.withDayOfYear(366))
     val days = Seq(Int.MinValue, 0, 367, Int.MaxValue)
     for {
       d <- samples
       n <- days
     } {
-      expectThrows(classOf[DateTimeException], d.withDayOfMonth(n))
+      assertThrows(classOf[DateTimeException], d.withDayOfMonth(n))
     }
   }
 
@@ -374,12 +374,12 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(leapDate.plusYears(2))(of(2014, 2, 28))
     testDateTime(MIN.plusYears(1999999998))(of(999999999, 1, 1))
     testDateTime(MAX.plusYears(-1999999998))(of(-999999999, 12, 31))
-    expectThrows(classOf[DateTimeException], MIN.plusYears(-1))
-    expectThrows(classOf[DateTimeException], MIN.plusYears(1999999999))
-    expectThrows(classOf[DateTimeException], MAX.plusYears(-1999999999))
-    expectThrows(classOf[DateTimeException], MAX.plusYears(1))
-    expectThrows(classOf[DateTimeException], MIN.plusYears(Long.MinValue))
-    expectThrows(classOf[DateTimeException], MAX.plusYears(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], MIN.plusYears(-1))
+    assertThrows(classOf[DateTimeException], MIN.plusYears(1999999999))
+    assertThrows(classOf[DateTimeException], MAX.plusYears(-1999999999))
+    assertThrows(classOf[DateTimeException], MAX.plusYears(1))
+    assertThrows(classOf[DateTimeException], MIN.plusYears(Long.MinValue))
+    assertThrows(classOf[DateTimeException], MAX.plusYears(Long.MaxValue))
   }
 
   @Test def test_plusMonths(): Unit = {
@@ -401,12 +401,12 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(of(2012, 3, 31).plusMonths(1))(of(2012, 4, 30))
     testDateTime(MIN.plusMonths(23999999987L))(of(999999999, 12, 1))
     testDateTime(MAX.plusMonths(-23999999987L))(of(-999999999, 1, 31))
-    expectThrows(classOf[DateTimeException], MIN.plusMonths(-1))
-    expectThrows(classOf[DateTimeException], MIN.plusMonths(23999999988L))
-    expectThrows(classOf[DateTimeException], MAX.plusMonths(-23999999988L))
-    expectThrows(classOf[DateTimeException], MAX.plusMonths(1))
-    expectThrows(classOf[DateTimeException], MIN.plusMonths(Long.MinValue))
-    expectThrows(classOf[DateTimeException], MAX.plusMonths(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], MIN.plusMonths(-1))
+    assertThrows(classOf[DateTimeException], MIN.plusMonths(23999999988L))
+    assertThrows(classOf[DateTimeException], MAX.plusMonths(-23999999988L))
+    assertThrows(classOf[DateTimeException], MAX.plusMonths(1))
+    assertThrows(classOf[DateTimeException], MIN.plusMonths(Long.MinValue))
+    assertThrows(classOf[DateTimeException], MAX.plusMonths(Long.MaxValue))
   }
 
   @Test def test_plusWeeks(): Unit = {
@@ -426,12 +426,12 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(leapDate.plusWeeks(53))(of(2013, 3, 6))
     testDateTime(MIN.plusWeeks(104354999947L))(of(999999999, 12, 27))
     testDateTime(MAX.plusWeeks(-104354999947L))(of(-999999999, 1, 5))
-    expectThrows(classOf[DateTimeException], MIN.plusWeeks(-1))
-    expectThrows(classOf[DateTimeException], MIN.plusWeeks(104354999948L))
-    expectThrows(classOf[DateTimeException], MAX.plusWeeks(-1043549999478L))
-    expectThrows(classOf[DateTimeException], MAX.plusWeeks(1))
-    expectThrows(classOf[ArithmeticException], MIN.plusWeeks(Long.MinValue))
-    expectThrows(classOf[ArithmeticException], MAX.plusWeeks(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], MIN.plusWeeks(-1))
+    assertThrows(classOf[DateTimeException], MIN.plusWeeks(104354999948L))
+    assertThrows(classOf[DateTimeException], MAX.plusWeeks(-1043549999478L))
+    assertThrows(classOf[DateTimeException], MAX.plusWeeks(1))
+    assertThrows(classOf[ArithmeticException], MIN.plusWeeks(Long.MinValue))
+    assertThrows(classOf[ArithmeticException], MAX.plusWeeks(Long.MaxValue))
   }
 
   @Test def test_plusDays(): Unit = {
@@ -450,17 +450,17 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(leapDate.plusDays(366))(of(2013, 3, 1))
     testDateTime(MIN.plusDays(730484999633L))(MAX)
     testDateTime(MAX.plusDays(-730484999633L))(MIN)
-    expectThrows(classOf[DateTimeException], MIN.plusDays(-1))
-    expectThrows(classOf[DateTimeException], MIN.plusDays(730484999634L))
-    expectThrows(classOf[DateTimeException], MAX.plusDays(-730484999634L))
-    expectThrows(classOf[DateTimeException], MAX.plusDays(1))
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[DateTimeException], MIN.plusDays(-1))
+    assertThrows(classOf[DateTimeException], MIN.plusDays(730484999634L))
+    assertThrows(classOf[DateTimeException], MAX.plusDays(-730484999634L))
+    assertThrows(classOf[DateTimeException], MAX.plusDays(1))
+    assertThrows(classOf[ArithmeticException],
         ofEpochDay(-1).plusDays(Long.MinValue))
-    expectThrows(classOf[DateTimeException],
+    assertThrows(classOf[DateTimeException],
         ofEpochDay(0).plusDays(Long.MinValue))
-    expectThrows(classOf[DateTimeException],
+    assertThrows(classOf[DateTimeException],
         ofEpochDay(0).plusDays(Long.MaxValue))
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException],
         ofEpochDay(1).plusDays(Long.MaxValue))
   }
 
@@ -477,12 +477,12 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(leapDate.minusYears(-2))(of(2014, 2, 28))
     testDateTime(MIN.minusYears(-1999999998))(of(999999999, 1, 1))
     testDateTime(MAX.minusYears(1999999998))(of(-999999999, 12, 31))
-    expectThrows(classOf[DateTimeException], MIN.minusYears(1))
-    expectThrows(classOf[DateTimeException], MIN.minusYears(-1999999999))
-    expectThrows(classOf[DateTimeException], MAX.minusYears(1999999999))
-    expectThrows(classOf[DateTimeException], MAX.minusYears(-1))
-    expectThrows(classOf[DateTimeException], MIN.minusYears(Long.MaxValue))
-    expectThrows(classOf[DateTimeException], MAX.minusYears(Long.MinValue))
+    assertThrows(classOf[DateTimeException], MIN.minusYears(1))
+    assertThrows(classOf[DateTimeException], MIN.minusYears(-1999999999))
+    assertThrows(classOf[DateTimeException], MAX.minusYears(1999999999))
+    assertThrows(classOf[DateTimeException], MAX.minusYears(-1))
+    assertThrows(classOf[DateTimeException], MIN.minusYears(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], MAX.minusYears(Long.MinValue))
   }
 
   @Test def test_minusMonths(): Unit = {
@@ -504,12 +504,12 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(of(2012, 3, 31).minusMonths(-1))(of(2012, 4, 30))
     testDateTime(MIN.minusMonths(-23999999987L))(of(999999999, 12, 1))
     testDateTime(MAX.minusMonths(23999999987L))(of(-999999999, 1, 31))
-    expectThrows(classOf[DateTimeException], MIN.minusMonths(1))
-    expectThrows(classOf[DateTimeException], MIN.minusMonths(-23999999988L))
-    expectThrows(classOf[DateTimeException], MAX.minusMonths(23999999988L))
-    expectThrows(classOf[DateTimeException], MAX.minusMonths(-1))
-    expectThrows(classOf[DateTimeException], MIN.minusMonths(Long.MaxValue))
-    expectThrows(classOf[DateTimeException], MAX.minusMonths(Long.MinValue))
+    assertThrows(classOf[DateTimeException], MIN.minusMonths(1))
+    assertThrows(classOf[DateTimeException], MIN.minusMonths(-23999999988L))
+    assertThrows(classOf[DateTimeException], MAX.minusMonths(23999999988L))
+    assertThrows(classOf[DateTimeException], MAX.minusMonths(-1))
+    assertThrows(classOf[DateTimeException], MIN.minusMonths(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], MAX.minusMonths(Long.MinValue))
   }
 
   @Test def test_minusWeeks(): Unit = {
@@ -529,12 +529,12 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(leapDate.minusWeeks(-53))(of(2013, 3, 6))
     testDateTime(MIN.minusWeeks(-104354999947L))(of(999999999, 12, 27))
     testDateTime(MAX.minusWeeks(104354999947L))(of(-999999999, 1, 5))
-    expectThrows(classOf[DateTimeException], MIN.minusWeeks(1))
-    expectThrows(classOf[DateTimeException], MIN.minusWeeks(-104354999948L))
-    expectThrows(classOf[DateTimeException], MAX.minusWeeks(1043549999478L))
-    expectThrows(classOf[DateTimeException], MAX.minusWeeks(-1))
-    expectThrows(classOf[ArithmeticException], MIN.minusWeeks(Long.MaxValue))
-    expectThrows(classOf[ArithmeticException], MAX.minusWeeks(Long.MinValue))
+    assertThrows(classOf[DateTimeException], MIN.minusWeeks(1))
+    assertThrows(classOf[DateTimeException], MIN.minusWeeks(-104354999948L))
+    assertThrows(classOf[DateTimeException], MAX.minusWeeks(1043549999478L))
+    assertThrows(classOf[DateTimeException], MAX.minusWeeks(-1))
+    assertThrows(classOf[ArithmeticException], MIN.minusWeeks(Long.MaxValue))
+    assertThrows(classOf[ArithmeticException], MAX.minusWeeks(Long.MinValue))
   }
 
   @Test def test_minusDays(): Unit = {
@@ -553,13 +553,13 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(leapDate.minusDays(-366))(of(2013, 3, 1))
     testDateTime(MIN.minusDays(-730484999633L))(MAX)
     testDateTime(MAX.minusDays(730484999633L))(MIN)
-    expectThrows(classOf[DateTimeException], MIN.minusDays(1))
-    expectThrows(classOf[DateTimeException], MIN.minusDays(-730484999634L))
-    expectThrows(classOf[DateTimeException], MAX.minusDays(730484999634L))
-    expectThrows(classOf[DateTimeException], MAX.minusDays(-1))
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[DateTimeException], MIN.minusDays(1))
+    assertThrows(classOf[DateTimeException], MIN.minusDays(-730484999634L))
+    assertThrows(classOf[DateTimeException], MAX.minusDays(730484999634L))
+    assertThrows(classOf[DateTimeException], MAX.minusDays(-1))
+    assertThrows(classOf[ArithmeticException],
         ofEpochDay(-2).minusDays(Long.MaxValue))
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException],
         ofEpochDay(1).minusDays(Long.MinValue))
   }
 
@@ -576,7 +576,7 @@ class LocalDateTest extends TemporalTest[LocalDate] {
       d <- samples
       t <- ts
     } {
-      expectThrows(classOf[DateTimeException], d.adjustInto(t))
+      assertThrows(classOf[DateTimeException], d.adjustInto(t))
     }
   }
 
@@ -623,7 +623,7 @@ class LocalDateTest extends TemporalTest[LocalDate] {
       d2 <- samples1
       u <- timeBasedUnits
     } {
-      expectThrows(classOf[UnsupportedTemporalTypeException], d1.until(d2, u))
+      assertThrows(classOf[UnsupportedTemporalTypeException], d1.until(d2, u))
     }
 
     assertEquals(Period.of(1999999998, 11, 30), MIN.until(MAX))
@@ -713,22 +713,22 @@ class LocalDateTest extends TemporalTest[LocalDate] {
       testDateTime(of(year, month, day))(of(year, month.getValue, day))
     }
 
-    expectThrows(classOf[DateTimeException], of(Int.MinValue, 1, 1))
-    expectThrows(classOf[DateTimeException], of(-1000000000, 1, 1))
-    expectThrows(classOf[DateTimeException], of(2011, Int.MinValue, 1))
-    expectThrows(classOf[DateTimeException], of(2011, 0, 1))
-    expectThrows(classOf[DateTimeException], of(2011, 13, 1))
-    expectThrows(classOf[DateTimeException], of(2011, Int.MaxValue, 1))
+    assertThrows(classOf[DateTimeException], of(Int.MinValue, 1, 1))
+    assertThrows(classOf[DateTimeException], of(-1000000000, 1, 1))
+    assertThrows(classOf[DateTimeException], of(2011, Int.MinValue, 1))
+    assertThrows(classOf[DateTimeException], of(2011, 0, 1))
+    assertThrows(classOf[DateTimeException], of(2011, 13, 1))
+    assertThrows(classOf[DateTimeException], of(2011, Int.MaxValue, 1))
 
     for (month <- Month.values) {
       val m = month.getValue
-      expectThrows(classOf[DateTimeException], of(2011, m, Int.MinValue))
-      expectThrows(classOf[DateTimeException], of(2011, m, 0))
-      expectThrows(classOf[DateTimeException],
+      assertThrows(classOf[DateTimeException], of(2011, m, Int.MinValue))
+      assertThrows(classOf[DateTimeException], of(2011, m, 0))
+      assertThrows(classOf[DateTimeException],
           of(2011, m, month.length(false) + 1))
-      expectThrows(classOf[DateTimeException],
+      assertThrows(classOf[DateTimeException],
           of(2012, m, month.length(true) + 1))
-      expectThrows(classOf[DateTimeException], of(2011, m, Int.MaxValue))
+      assertThrows(classOf[DateTimeException], of(2011, m, Int.MaxValue))
     }
   }
 
@@ -782,15 +782,15 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(ofYearDay(2012, 336))(of(2012, 12, 1))
     testDateTime(ofYearDay(2012, 366))(of(2012, 12, 31))
 
-    expectThrows(classOf[DateTimeException], ofYearDay(Int.MinValue, 1))
-    expectThrows(classOf[DateTimeException], ofYearDay(-1000000000, 1))
-    expectThrows(classOf[DateTimeException], ofYearDay(1000000000, 1))
-    expectThrows(classOf[DateTimeException], ofYearDay(Int.MaxValue, 1))
-    expectThrows(classOf[DateTimeException], ofYearDay(2011, Int.MinValue))
-    expectThrows(classOf[DateTimeException], ofYearDay(2011, 0))
-    expectThrows(classOf[DateTimeException], ofYearDay(2011, 366))
-    expectThrows(classOf[DateTimeException], ofYearDay(2012, 367))
-    expectThrows(classOf[DateTimeException], ofYearDay(2011, Int.MaxValue))
+    assertThrows(classOf[DateTimeException], ofYearDay(Int.MinValue, 1))
+    assertThrows(classOf[DateTimeException], ofYearDay(-1000000000, 1))
+    assertThrows(classOf[DateTimeException], ofYearDay(1000000000, 1))
+    assertThrows(classOf[DateTimeException], ofYearDay(Int.MaxValue, 1))
+    assertThrows(classOf[DateTimeException], ofYearDay(2011, Int.MinValue))
+    assertThrows(classOf[DateTimeException], ofYearDay(2011, 0))
+    assertThrows(classOf[DateTimeException], ofYearDay(2011, 366))
+    assertThrows(classOf[DateTimeException], ofYearDay(2012, 367))
+    assertThrows(classOf[DateTimeException], ofYearDay(2011, Int.MaxValue))
   }
 
   @Test def test_ofEpochDay(): Unit = {
@@ -800,10 +800,10 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     testDateTime(ofEpochDay(1))(of(1970, 1, 2))
     testDateTime(ofEpochDay(365241780471L))(MAX)
 
-    expectThrows(classOf[DateTimeException], ofEpochDay(Long.MinValue))
-    expectThrows(classOf[DateTimeException], ofEpochDay(-365243219163L))
-    expectThrows(classOf[DateTimeException], ofEpochDay(365241780472L))
-    expectThrows(classOf[DateTimeException], ofEpochDay(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], ofEpochDay(Long.MinValue))
+    assertThrows(classOf[DateTimeException], ofEpochDay(-365243219163L))
+    assertThrows(classOf[DateTimeException], ofEpochDay(365241780472L))
+    assertThrows(classOf[DateTimeException], ofEpochDay(Long.MaxValue))
   }
 
   @Test def test_from(): Unit = {
@@ -811,7 +811,7 @@ class LocalDateTest extends TemporalTest[LocalDate] {
       testDateTime(from(d))(d)
 
     for (t <- Seq(LocalTime.MIN, LocalTime.NOON, LocalTime.MAX))
-      expectThrows(classOf[DateTimeException], from(t))
+      assertThrows(classOf[DateTimeException], from(t))
   }
 
   @Test def test_parse(): Unit = {
@@ -824,11 +824,11 @@ class LocalDateTest extends TemporalTest[LocalDate] {
     assertEquals(parse("+10000-01-01"), of(10000, 1, 1))
     assertEquals(parse("+999999999-12-31"), MAX)
 
-    expectThrows(classOf[DateTimeParseException], parse("0000-01-99"))
-    expectThrows(classOf[DateTimeParseException], parse("0000-01-900"))
-    expectThrows(classOf[DateTimeParseException], parse("aaaa-01-30"))
-    expectThrows(classOf[DateTimeParseException], parse("2012-13-30"))
-    expectThrows(classOf[DateTimeParseException], parse("2012-01-34"))
-    expectThrows(classOf[DateTimeParseException], parse("2005-02-29"))
+    assertThrows(classOf[DateTimeParseException], parse("0000-01-99"))
+    assertThrows(classOf[DateTimeParseException], parse("0000-01-900"))
+    assertThrows(classOf[DateTimeParseException], parse("aaaa-01-30"))
+    assertThrows(classOf[DateTimeParseException], parse("2012-13-30"))
+    assertThrows(classOf[DateTimeParseException], parse("2012-01-34"))
+    assertThrows(classOf[DateTimeParseException], parse("2005-02-29"))
   }
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/LocalTimeTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/LocalTimeTest.scala
@@ -4,8 +4,8 @@ import java.time._
 import java.time.temporal._
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class LocalTimeTest extends TemporalTest[LocalTime] {
 
@@ -120,35 +120,35 @@ class LocalTimeTest extends TemporalTest[LocalTime] {
       }
 
       for (n <- Seq(Long.MinValue, -1L, 1000000000L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(NANO_OF_SECOND, n))
+        assertThrows(classOf[DateTimeException], t.`with`(NANO_OF_SECOND, n))
       for (n <- Seq(Long.MinValue, -1L, 86400000000000L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(NANO_OF_DAY, n))
+        assertThrows(classOf[DateTimeException], t.`with`(NANO_OF_DAY, n))
       for (n <- Seq(Long.MinValue, -1L, 1000000L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(MICRO_OF_SECOND, n))
+        assertThrows(classOf[DateTimeException], t.`with`(MICRO_OF_SECOND, n))
       for (n <- Seq(Long.MinValue, -1L, 86400000000L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(MICRO_OF_DAY, n))
+        assertThrows(classOf[DateTimeException], t.`with`(MICRO_OF_DAY, n))
       for (n <- Seq(Long.MinValue, -1L, 1000L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(MILLI_OF_SECOND, n))
+        assertThrows(classOf[DateTimeException], t.`with`(MILLI_OF_SECOND, n))
       for (n <- Seq(Long.MinValue, -1L, 86400000L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(MILLI_OF_DAY, n))
+        assertThrows(classOf[DateTimeException], t.`with`(MILLI_OF_DAY, n))
       for (n <- Seq(Long.MinValue, -1L, 60L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(SECOND_OF_MINUTE, n))
+        assertThrows(classOf[DateTimeException], t.`with`(SECOND_OF_MINUTE, n))
       for (n <- Seq(Long.MinValue, -1L, 86400L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(SECOND_OF_DAY, n))
+        assertThrows(classOf[DateTimeException], t.`with`(SECOND_OF_DAY, n))
       for (n <- Seq(Long.MinValue, -1L, 60L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(MINUTE_OF_HOUR, n))
+        assertThrows(classOf[DateTimeException], t.`with`(MINUTE_OF_HOUR, n))
       for (n <- Seq(Long.MinValue, -1L, 1440L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(MINUTE_OF_DAY, n))
+        assertThrows(classOf[DateTimeException], t.`with`(MINUTE_OF_DAY, n))
       for (n <- Seq(Long.MinValue, -1L, 12L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(HOUR_OF_AMPM, n))
+        assertThrows(classOf[DateTimeException], t.`with`(HOUR_OF_AMPM, n))
       for (n <- Seq(Long.MinValue, 0L, 13L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(CLOCK_HOUR_OF_AMPM, n))
+        assertThrows(classOf[DateTimeException], t.`with`(CLOCK_HOUR_OF_AMPM, n))
       for (n <- Seq(Long.MinValue, -1L, 24L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(HOUR_OF_DAY, n))
+        assertThrows(classOf[DateTimeException], t.`with`(HOUR_OF_DAY, n))
       for (n <- Seq(Long.MinValue, 0L, 25L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(CLOCK_HOUR_OF_DAY, n))
+        assertThrows(classOf[DateTimeException], t.`with`(CLOCK_HOUR_OF_DAY, n))
       for (n <- Seq(Long.MinValue, -1L, 2L, Long.MaxValue))
-        expectThrows(classOf[DateTimeException], t.`with`(AMPM_OF_DAY, n))
+        assertThrows(classOf[DateTimeException], t.`with`(AMPM_OF_DAY, n))
     }
   }
 
@@ -160,10 +160,10 @@ class LocalTimeTest extends TemporalTest[LocalTime] {
     testDateTime(MAX.withHour(23))(MAX)
 
     for (t <- samples) {
-      expectThrows(classOf[DateTimeException], t.withHour(Int.MinValue))
-      expectThrows(classOf[DateTimeException], t.withHour(-1))
-      expectThrows(classOf[DateTimeException], t.withHour(24))
-      expectThrows(classOf[DateTimeException], t.withHour(Int.MaxValue))
+      assertThrows(classOf[DateTimeException], t.withHour(Int.MinValue))
+      assertThrows(classOf[DateTimeException], t.withHour(-1))
+      assertThrows(classOf[DateTimeException], t.withHour(24))
+      assertThrows(classOf[DateTimeException], t.withHour(Int.MaxValue))
     }
   }
 
@@ -175,10 +175,10 @@ class LocalTimeTest extends TemporalTest[LocalTime] {
     testDateTime(MAX.withMinute(59))(MAX)
 
     for (t <- samples) {
-      expectThrows(classOf[DateTimeException], t.withMinute(Int.MinValue))
-      expectThrows(classOf[DateTimeException], t.withMinute(-1))
-      expectThrows(classOf[DateTimeException], t.withMinute(60))
-      expectThrows(classOf[DateTimeException], t.withMinute(Int.MaxValue))
+      assertThrows(classOf[DateTimeException], t.withMinute(Int.MinValue))
+      assertThrows(classOf[DateTimeException], t.withMinute(-1))
+      assertThrows(classOf[DateTimeException], t.withMinute(60))
+      assertThrows(classOf[DateTimeException], t.withMinute(Int.MaxValue))
     }
   }
 
@@ -190,10 +190,10 @@ class LocalTimeTest extends TemporalTest[LocalTime] {
     testDateTime(MAX.withSecond(59))(MAX)
 
     for (t <- samples) {
-      expectThrows(classOf[DateTimeException], t.withSecond(Int.MinValue))
-      expectThrows(classOf[DateTimeException], t.withSecond(-1))
-      expectThrows(classOf[DateTimeException], t.withSecond(60))
-      expectThrows(classOf[DateTimeException], t.withSecond(Int.MaxValue))
+      assertThrows(classOf[DateTimeException], t.withSecond(Int.MinValue))
+      assertThrows(classOf[DateTimeException], t.withSecond(-1))
+      assertThrows(classOf[DateTimeException], t.withSecond(60))
+      assertThrows(classOf[DateTimeException], t.withSecond(Int.MaxValue))
     }
   }
 
@@ -205,10 +205,10 @@ class LocalTimeTest extends TemporalTest[LocalTime] {
     testDateTime(MAX.withNano(999999999))(MAX)
 
     for (t <- samples) {
-      expectThrows(classOf[DateTimeException], t.withNano(Int.MinValue))
-      expectThrows(classOf[DateTimeException], t.withNano(-1))
-      expectThrows(classOf[DateTimeException], t.withNano(1000000000))
-      expectThrows(classOf[DateTimeException], t.withNano(Int.MaxValue))
+      assertThrows(classOf[DateTimeException], t.withNano(Int.MinValue))
+      assertThrows(classOf[DateTimeException], t.withNano(-1))
+      assertThrows(classOf[DateTimeException], t.withNano(1000000000))
+      assertThrows(classOf[DateTimeException], t.withNano(Int.MaxValue))
     }
   }
 
@@ -235,7 +235,7 @@ class LocalTimeTest extends TemporalTest[LocalTime] {
       t <- samples
       u <- illegalUnits
     } {
-      expectThrows(classOf[UnsupportedTemporalTypeException], t.truncatedTo(u))
+      assertThrows(classOf[UnsupportedTemporalTypeException], t.truncatedTo(u))
     }
   }
 
@@ -430,7 +430,7 @@ class LocalTimeTest extends TemporalTest[LocalTime] {
       t <- samples
       d <- ds
     } {
-      expectThrows(classOf[DateTimeException], t.adjustInto(d))
+      assertThrows(classOf[DateTimeException], t.adjustInto(d))
     }
   }
 
@@ -504,14 +504,14 @@ class LocalTimeTest extends TemporalTest[LocalTime] {
     testDateTime(of(23, 59, 59))(of(23, 59, 59, 0))
     testDateTime(of(23, 59, 59, 999999999))(MAX)
 
-    expectThrows(classOf[DateTimeException], of(-1, 0))
-    expectThrows(classOf[DateTimeException], of(0, -1))
-    expectThrows(classOf[DateTimeException], of(0, 0, -1))
-    expectThrows(classOf[DateTimeException], of(0, 0, 0, -1))
-    expectThrows(classOf[DateTimeException], of(24, 0))
-    expectThrows(classOf[DateTimeException], of(0, 60))
-    expectThrows(classOf[DateTimeException], of(0, 0, 60))
-    expectThrows(classOf[DateTimeException], of(0, 0, 0, 1000000000))
+    assertThrows(classOf[DateTimeException], of(-1, 0))
+    assertThrows(classOf[DateTimeException], of(0, -1))
+    assertThrows(classOf[DateTimeException], of(0, 0, -1))
+    assertThrows(classOf[DateTimeException], of(0, 0, 0, -1))
+    assertThrows(classOf[DateTimeException], of(24, 0))
+    assertThrows(classOf[DateTimeException], of(0, 60))
+    assertThrows(classOf[DateTimeException], of(0, 0, 60))
+    assertThrows(classOf[DateTimeException], of(0, 0, 0, 1000000000))
   }
 
   @Test def test_ofSecondOfDay(): Unit = {
@@ -520,8 +520,8 @@ class LocalTimeTest extends TemporalTest[LocalTime] {
     testDateTime(ofSecondOfDay(60))(of(0, 1))
     testDateTime(ofSecondOfDay(86399))(of(23, 59, 59))
 
-    expectThrows(classOf[DateTimeException], ofSecondOfDay(-1))
-    expectThrows(classOf[DateTimeException], ofSecondOfDay(86400))
+    assertThrows(classOf[DateTimeException], ofSecondOfDay(-1))
+    assertThrows(classOf[DateTimeException], ofSecondOfDay(86400))
   }
 
   @Test def test_ofNanoOfDay(): Unit = {
@@ -530,16 +530,16 @@ class LocalTimeTest extends TemporalTest[LocalTime] {
     testDateTime(ofNanoOfDay(1000000000))(of(0, 0, 1))
     testDateTime(ofNanoOfDay(86399999999999L))(MAX)
 
-    expectThrows(classOf[DateTimeException], ofNanoOfDay(-1))
-    expectThrows(classOf[DateTimeException], ofNanoOfDay(86400000000000L))
+    assertThrows(classOf[DateTimeException], ofNanoOfDay(-1))
+    assertThrows(classOf[DateTimeException], ofNanoOfDay(86400000000000L))
   }
 
   @Test def test_from(): Unit = {
     for (t <- samples)
       testDateTime(from(t))(t)
 
-    expectThrows(classOf[DateTimeException], from(LocalDate.of(2012, 2, 29)))
-    expectThrows(classOf[DateTimeException], from(Month.JANUARY))
-    expectThrows(classOf[DateTimeException], from(DayOfWeek.MONDAY))
+    assertThrows(classOf[DateTimeException], from(LocalDate.of(2012, 2, 29)))
+    assertThrows(classOf[DateTimeException], from(Month.JANUARY))
+    assertThrows(classOf[DateTimeException], from(DayOfWeek.MONDAY))
   }
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/MonthDayTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/MonthDayTest.scala
@@ -5,8 +5,8 @@ import java.time.temporal.{TemporalField, UnsupportedTemporalTypeException, Valu
 import java.time.{DateTimeException, LocalDate, Month, MonthDay}
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /** Created by alonsodomin on 22/12/2015. */
 class MonthDayTest extends TemporalAccessorTest[MonthDay] {
@@ -90,9 +90,9 @@ class MonthDayTest extends TemporalAccessorTest[MonthDay] {
     assertEquals(MonthDay.of(Month.FEBRUARY, 29), max.withMonth(2))
 
     for (t <- samples) {
-      expectThrows(classOf[DateTimeException], t.withMonth(Int.MinValue))
-      expectThrows(classOf[DateTimeException], t.withMonth(Int.MaxValue))
-      expectThrows(classOf[DateTimeException], t.withMonth(0))
+      assertThrows(classOf[DateTimeException], t.withMonth(Int.MinValue))
+      assertThrows(classOf[DateTimeException], t.withMonth(Int.MaxValue))
+      assertThrows(classOf[DateTimeException], t.withMonth(0))
     }
   }
 
@@ -104,9 +104,9 @@ class MonthDayTest extends TemporalAccessorTest[MonthDay] {
     assertEquals(MonthDay.of(Month.DECEMBER, 1), max.withDayOfMonth(1))
 
     for (t <- samples) {
-      expectThrows(classOf[DateTimeException], t.withDayOfMonth(Int.MinValue))
-      expectThrows(classOf[DateTimeException], t.withDayOfMonth(Int.MaxValue))
-      expectThrows(classOf[DateTimeException], t.withDayOfMonth(t.getMonth.maxLength() + 1))
+      assertThrows(classOf[DateTimeException], t.withDayOfMonth(Int.MinValue))
+      assertThrows(classOf[DateTimeException], t.withDayOfMonth(Int.MaxValue))
+      assertThrows(classOf[DateTimeException], t.withDayOfMonth(t.getMonth.maxLength() + 1))
     }
   }
 
@@ -134,7 +134,7 @@ class MonthDayTest extends TemporalAccessorTest[MonthDay] {
 
     val invalidYears = Seq(Int.MinValue, -1000000000, 1000000000, Int.MaxValue)
     for (t <- samples; y <- invalidYears) {
-      expectThrows(classOf[DateTimeException], t.atYear(y))
+      assertThrows(classOf[DateTimeException], t.atYear(y))
     }
 
     for (y <- yearSamples) {
@@ -179,19 +179,19 @@ class MonthDayTest extends TemporalAccessorTest[MonthDay] {
   }
 
   @Test def ofMonth(): Unit = {
-    expectThrows(classOf[NullPointerException], MonthDay.of(null, 1))
-    expectThrows(classOf[DateTimeException], MonthDay.of(Month.JANUARY, Int.MinValue))
-    expectThrows(classOf[DateTimeException], MonthDay.of(Month.JANUARY, Int.MaxValue))
-    expectThrows(classOf[DateTimeException], MonthDay.of(Month.JANUARY, 32))
-    expectThrows(classOf[DateTimeException], MonthDay.of(Month.FEBRUARY, 30))
+    assertThrows(classOf[NullPointerException], MonthDay.of(null, 1))
+    assertThrows(classOf[DateTimeException], MonthDay.of(Month.JANUARY, Int.MinValue))
+    assertThrows(classOf[DateTimeException], MonthDay.of(Month.JANUARY, Int.MaxValue))
+    assertThrows(classOf[DateTimeException], MonthDay.of(Month.JANUARY, 32))
+    assertThrows(classOf[DateTimeException], MonthDay.of(Month.FEBRUARY, 30))
 
     assertEquals(min, MonthDay.of(Month.JANUARY, 1))
     assertEquals(max, MonthDay.of(Month.DECEMBER, 31))
   }
 
   @Test def of(): Unit = {
-    expectThrows(classOf[DateTimeException], MonthDay.of(Int.MinValue, 1))
-    expectThrows(classOf[DateTimeException], MonthDay.of(Int.MaxValue, 1))
+    assertThrows(classOf[DateTimeException], MonthDay.of(Int.MinValue, 1))
+    assertThrows(classOf[DateTimeException], MonthDay.of(Int.MaxValue, 1))
 
     assertEquals(min, MonthDay.of(1, 1))
     assertEquals(max, MonthDay.of(12, 31))

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/MonthTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/MonthTest.scala
@@ -4,8 +4,8 @@ import java.time._
 import java.time.temporal.ChronoField
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.{assertEquals, assertArrayEquals}
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class MonthTest extends TemporalAccessorTest[Month] {
   import Month._
@@ -160,7 +160,7 @@ class MonthTest extends TemporalAccessorTest[Month] {
     assertEquals(NOVEMBER, valueOf("NOVEMBER"))
     assertEquals(DECEMBER, valueOf("DECEMBER"))
 
-    expectThrows(classOf[IllegalArgumentException], valueOf(""))
+    assertThrows(classOf[IllegalArgumentException], valueOf(""))
   }
 
   @Test def test_of(): Unit = {
@@ -178,7 +178,7 @@ class MonthTest extends TemporalAccessorTest[Month] {
     assertEquals(DECEMBER, of(12))
 
     for (n <- Seq(Int.MinValue, 0, 13, Int.MaxValue))
-      expectThrows(classOf[DateTimeException], of(n))
+      assertThrows(classOf[DateTimeException], of(n))
   }
 
   @Test def test_from(): Unit = {
@@ -187,7 +187,7 @@ class MonthTest extends TemporalAccessorTest[Month] {
       assertEquals(m, from(LocalDate.of(1, m, 1)))
     }
 
-    expectThrows(classOf[DateTimeException], from(DayOfWeek.MONDAY))
-    expectThrows(classOf[DateTimeException], from(LocalTime.MIN))
+    assertThrows(classOf[DateTimeException], from(DayOfWeek.MONDAY))
+    assertThrows(classOf[DateTimeException], from(LocalTime.MIN))
   }
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/PeriodTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/PeriodTest.scala
@@ -5,8 +5,8 @@ import java.time.chrono.IsoChronology
 import java.time.temporal.ChronoUnit
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class PeriodTest extends TemporalAmountTest[Period] {
 
@@ -132,11 +132,11 @@ class PeriodTest extends TemporalAmountTest[Period] {
     }
 
     for (p <- Seq(oneYear, oneMonth, oneDay))
-      expectThrows(classOf[ArithmeticException], pmax.plus(p))
+      assertThrows(classOf[ArithmeticException], pmax.plus(p))
     for (p <- Seq(oneYear.negated, oneMonth.negated, oneDay.negated))
-      expectThrows(classOf[ArithmeticException], pmin.plus(p))
+      assertThrows(classOf[ArithmeticException], pmin.plus(p))
     for (p <- samples)
-      expectThrows(classOf[DateTimeException], p.plus(Duration.ZERO))
+      assertThrows(classOf[DateTimeException], p.plus(Duration.ZERO))
   }
 
   @Test def test_plusYears(): Unit = {
@@ -150,11 +150,11 @@ class PeriodTest extends TemporalAmountTest[Period] {
       assertEquals(p.getDays, p1.getDays)
     }
 
-    expectThrows(classOf[ArithmeticException], oneYear.plusYears(Int.MaxValue))
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException], oneYear.plusYears(Int.MaxValue))
+    assertThrows(classOf[ArithmeticException],
         oneYear.negated.plusYears(Int.MinValue))
-    expectThrows(classOf[ArithmeticException], pmax.plusYears(1))
-    expectThrows(classOf[ArithmeticException], pmin.plusYears(-1))
+    assertThrows(classOf[ArithmeticException], pmax.plusYears(1))
+    assertThrows(classOf[ArithmeticException], pmin.plusYears(-1))
   }
 
   @Test def test_plusMonths(): Unit = {
@@ -168,11 +168,11 @@ class PeriodTest extends TemporalAmountTest[Period] {
       assertEquals(p.getDays, p1.getDays)
     }
 
-    expectThrows(classOf[ArithmeticException], oneMonth.plusMonths(Int.MaxValue))
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException], oneMonth.plusMonths(Int.MaxValue))
+    assertThrows(classOf[ArithmeticException],
         oneMonth.negated.plusMonths(Int.MinValue))
-    expectThrows(classOf[ArithmeticException], pmax.plusMonths(1))
-    expectThrows(classOf[ArithmeticException], pmin.plusMonths(-1))
+    assertThrows(classOf[ArithmeticException], pmax.plusMonths(1))
+    assertThrows(classOf[ArithmeticException], pmin.plusMonths(-1))
   }
 
   @Test def test_plusDays(): Unit = {
@@ -186,11 +186,11 @@ class PeriodTest extends TemporalAmountTest[Period] {
       assertEquals(p.getDays + n, p1.getDays)
     }
 
-    expectThrows(classOf[ArithmeticException], oneDay.plusDays(Int.MaxValue))
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException], oneDay.plusDays(Int.MaxValue))
+    assertThrows(classOf[ArithmeticException],
         oneDay.negated.plusDays(Int.MinValue))
-    expectThrows(classOf[ArithmeticException], pmax.plusDays(1))
-    expectThrows(classOf[ArithmeticException], pmin.plusDays(-1))
+    assertThrows(classOf[ArithmeticException], pmax.plusDays(1))
+    assertThrows(classOf[ArithmeticException], pmin.plusDays(-1))
   }
 
   @Test def test_minus(): Unit = {
@@ -205,11 +205,11 @@ class PeriodTest extends TemporalAmountTest[Period] {
     }
 
     for (p <- Seq(oneYear, oneMonth, oneDay))
-      expectThrows(classOf[ArithmeticException], pmin.minus(p))
+      assertThrows(classOf[ArithmeticException], pmin.minus(p))
     for (p <- Seq(oneYear.negated, oneMonth.negated, oneDay.negated))
-      expectThrows(classOf[ArithmeticException], pmax.minus(p))
+      assertThrows(classOf[ArithmeticException], pmax.minus(p))
     for (p <- samples)
-      expectThrows(classOf[DateTimeException], p.minus(Duration.ZERO))
+      assertThrows(classOf[DateTimeException], p.minus(Duration.ZERO))
   }
 
   @Test def test_minusYears(): Unit = {
@@ -223,10 +223,10 @@ class PeriodTest extends TemporalAmountTest[Period] {
       assertEquals(p.getDays, p1.getDays)
     }
 
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException],
         oneYear.minusYears(Int.MinValue + 1))
-    expectThrows(classOf[ArithmeticException], pmin.minusYears(1))
-    expectThrows(classOf[ArithmeticException], pmax.minusYears(-1))
+    assertThrows(classOf[ArithmeticException], pmin.minusYears(1))
+    assertThrows(classOf[ArithmeticException], pmax.minusYears(-1))
   }
 
   @Test def test_minusMonths(): Unit = {
@@ -240,10 +240,10 @@ class PeriodTest extends TemporalAmountTest[Period] {
       assertEquals(p.getDays, p1.getDays)
     }
 
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException],
         oneMonth.minusMonths(Int.MinValue + 1))
-    expectThrows(classOf[ArithmeticException], pmin.minusMonths(1))
-    expectThrows(classOf[ArithmeticException], pmax.minusMonths(-1))
+    assertThrows(classOf[ArithmeticException], pmin.minusMonths(1))
+    assertThrows(classOf[ArithmeticException], pmax.minusMonths(-1))
   }
 
   @Test def test_minusDays(): Unit = {
@@ -257,10 +257,10 @@ class PeriodTest extends TemporalAmountTest[Period] {
       assertEquals(p.getDays - n, p1.getDays)
     }
 
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException],
         oneDay.minusDays(Int.MinValue + 1))
-    expectThrows(classOf[ArithmeticException], pmin.minusDays(1))
-    expectThrows(classOf[ArithmeticException], pmax.minusDays(-1))
+    assertThrows(classOf[ArithmeticException], pmin.minusDays(1))
+    assertThrows(classOf[ArithmeticException], pmax.minusDays(-1))
   }
 
   @Test def test_multipliedBy(): Unit = {
@@ -281,19 +281,19 @@ class PeriodTest extends TemporalAmountTest[Period] {
     for (p <- samples if p != pmin)
       assertEquals(p.negated, p.multipliedBy(-1))
 
-    expectThrows(classOf[ArithmeticException], pmin.multipliedBy(2))
-    expectThrows(classOf[ArithmeticException], pmin.multipliedBy(-1))
+    assertThrows(classOf[ArithmeticException], pmin.multipliedBy(2))
+    assertThrows(classOf[ArithmeticException], pmin.multipliedBy(-1))
     for (p <- Seq(pmin1, pmax)) {
-      expectThrows(classOf[ArithmeticException], p.multipliedBy(2))
-      expectThrows(classOf[ArithmeticException], p.multipliedBy(-2))
+      assertThrows(classOf[ArithmeticException], p.multipliedBy(2))
+      assertThrows(classOf[ArithmeticException], p.multipliedBy(-2))
     }
     for (p <- samples1 if p != ZERO) {
       val p2 = p.multipliedBy(2)
-      expectThrows(classOf[ArithmeticException], p2.multipliedBy(Int.MaxValue))
-      expectThrows(classOf[ArithmeticException], p2.multipliedBy(Int.MinValue))
+      assertThrows(classOf[ArithmeticException], p2.multipliedBy(Int.MaxValue))
+      assertThrows(classOf[ArithmeticException], p2.multipliedBy(Int.MinValue))
     }
     for (p <- Seq(oneYear.negated, oneMonth.negated, oneDay.negated))
-      expectThrows(classOf[ArithmeticException], p.multipliedBy(Int.MinValue))
+      assertThrows(classOf[ArithmeticException], p.multipliedBy(Int.MinValue))
   }
 
   @Test def test_negated(): Unit = {
@@ -304,7 +304,7 @@ class PeriodTest extends TemporalAmountTest[Period] {
       assertEquals(-p.getDays, p1.getDays)
     }
 
-    expectThrows(classOf[ArithmeticException], pmin.negated)
+    assertThrows(classOf[ArithmeticException], pmin.negated)
   }
 
   @Test def test_normalized(): Unit = {
@@ -321,7 +321,7 @@ class PeriodTest extends TemporalAmountTest[Period] {
     }
 
     for (p <- Seq(pmin, pmin1, pmax))
-      expectThrows(classOf[ArithmeticException], p.normalized)
+      assertThrows(classOf[ArithmeticException], p.normalized)
   }
 
   @Test def test_toTotalMonths(): Unit = {
@@ -353,14 +353,14 @@ class PeriodTest extends TemporalAmountTest[Period] {
       LocalDate.of(2012, 2, 29))
 
     for (p <- Seq(oneYear, oneMonth, oneYear, pmin, pmax))
-      expectThrows(classOf[DateTimeException], p.addTo(LocalDate.MAX))
+      assertThrows(classOf[DateTimeException], p.addTo(LocalDate.MAX))
     for (p <- Seq(oneYear.negated, oneMonth.negated, oneYear.negated, pmin, pmax))
-      expectThrows(classOf[DateTimeException], p.addTo(LocalDate.MIN))
+      assertThrows(classOf[DateTimeException], p.addTo(LocalDate.MIN))
     for {
       p <- samples if p != ZERO
       t <- ts
     } {
-      expectThrows(classOf[DateTimeException], p.addTo(t))
+      assertThrows(classOf[DateTimeException], p.addTo(t))
     }
   }
 
@@ -385,14 +385,14 @@ class PeriodTest extends TemporalAmountTest[Period] {
       LocalDate.of(2012, 2, 29))
 
     for (p <- Seq(oneYear.negated, oneMonth.negated, oneYear.negated, pmin, pmax))
-      expectThrows(classOf[DateTimeException], p.subtractFrom(LocalDate.MAX))
+      assertThrows(classOf[DateTimeException], p.subtractFrom(LocalDate.MAX))
     for (p <- Seq(oneYear, oneMonth, oneYear, pmin, pmax))
-      expectThrows(classOf[DateTimeException], p.subtractFrom(LocalDate.MIN))
+      assertThrows(classOf[DateTimeException], p.subtractFrom(LocalDate.MIN))
     for {
       p <- samples if p != ZERO
       t <- ts
     } {
-      expectThrows(classOf[DateTimeException], p.subtractFrom(t))
+      assertThrows(classOf[DateTimeException], p.subtractFrom(t))
     }
   }
 

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/TemporalAccessorTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/TemporalAccessorTest.scala
@@ -4,8 +4,8 @@ import java.time.DateTimeException
 import java.time.temporal._
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 abstract class TemporalAccessorTest[TempAcc <: TemporalAccessor] {
   val samples: Seq[TempAcc]
@@ -37,7 +37,7 @@ abstract class TemporalAccessorTest[TempAcc <: TemporalAccessor] {
         val expected = expectedRangeFor(accessor, field)
         assertEquals(expected, accessor.range(field))
       } else {
-        expectThrows(classOf[UnsupportedTemporalTypeException], accessor.range(field))
+        assertThrows(classOf[UnsupportedTemporalTypeException], accessor.range(field))
       }
     }
   }
@@ -50,9 +50,9 @@ abstract class TemporalAccessorTest[TempAcc <: TemporalAccessor] {
       if (accessor.isSupported(field) && field.range.isIntValue)
         assertEquals(accessor.getLong(field), accessor.get(field).toLong)
       else if (accessor.isSupported(field))
-        expectThrows(classOf[DateTimeException], accessor.get(field))
+        assertThrows(classOf[DateTimeException], accessor.get(field))
       else
-        expectThrows(classOf[UnsupportedTemporalTypeException], accessor.get(field))
+        assertThrows(classOf[UnsupportedTemporalTypeException], accessor.get(field))
     }
   }
 
@@ -61,7 +61,7 @@ abstract class TemporalAccessorTest[TempAcc <: TemporalAccessor] {
       accessor <- samples
       field <- ChronoField.values() if !accessor.isSupported(field)
     } {
-      expectThrows(classOf[UnsupportedTemporalTypeException],
+      assertThrows(classOf[UnsupportedTemporalTypeException],
           accessor.getLong(field))
     }
   }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/TemporalAmountTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/TemporalAmountTest.scala
@@ -3,8 +3,8 @@ package org.scalajs.testsuite.javalib.time
 import java.time.temporal.{UnsupportedTemporalTypeException, ChronoUnit, TemporalAmount}
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.{assertEquals, assertArrayEquals}
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 abstract class TemporalAmountTest[TempAmt <: TemporalAmount] {
   val samples: Seq[TempAmt]
@@ -17,7 +17,7 @@ abstract class TemporalAmountTest[TempAmt <: TemporalAmount] {
       amount <- samples
       unit <- illegalUnits
     } {
-      expectThrows(classOf[UnsupportedTemporalTypeException], amount.get(unit))
+      assertThrows(classOf[UnsupportedTemporalTypeException], amount.get(unit))
     }
   }
 

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/TemporalTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/TemporalTest.scala
@@ -3,8 +3,8 @@ package org.scalajs.testsuite.javalib.time
 import java.time.temporal._
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 abstract class TemporalTest[Temp <: Temporal] extends TemporalAccessorTest[Temp] {
   import DateTimeTestUtil._
@@ -37,7 +37,7 @@ abstract class TemporalTest[Temp <: Temporal] extends TemporalAccessorTest[Temp]
       field <- ChronoField.values if !temporal.isSupported(field)
       n <- sampleLongs.filter(field.range.isValidValue)
     } {
-      expectThrows(classOf[UnsupportedTemporalTypeException],
+      assertThrows(classOf[UnsupportedTemporalTypeException],
           temporal.`with`(field, n))
     }
   }
@@ -48,7 +48,7 @@ abstract class TemporalTest[Temp <: Temporal] extends TemporalAccessorTest[Temp]
       unit <- ChronoUnit.values if !temporal.isSupported(unit)
       n <- sampleLongs
     } {
-      expectThrows(classOf[UnsupportedTemporalTypeException],
+      assertThrows(classOf[UnsupportedTemporalTypeException],
           temporal.plus(n, unit))
     }
   }
@@ -72,7 +72,7 @@ abstract class TemporalTest[Temp <: Temporal] extends TemporalAccessorTest[Temp]
       unit <- ChronoUnit.values if !temporal.isSupported(unit)
       n <- sampleLongs
     } {
-      expectThrows(classOf[UnsupportedTemporalTypeException],
+      assertThrows(classOf[UnsupportedTemporalTypeException],
           temporal.minus(n, unit))
     }
   }
@@ -83,7 +83,7 @@ abstract class TemporalTest[Temp <: Temporal] extends TemporalAccessorTest[Temp]
       temporal2 <- samples
       unit <- ChronoUnit.values if !temporal1.isSupported(unit)
     } {
-      expectThrows(classOf[UnsupportedTemporalTypeException],
+      assertThrows(classOf[UnsupportedTemporalTypeException],
           temporal1.until(temporal2, unit))
     }
   }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/YearMonthTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/YearMonthTest.scala
@@ -4,8 +4,8 @@ import java.time._
 import java.time.temporal.{TemporalField, ValueRange, ChronoUnit, ChronoField}
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /** Created by alonsodomin on 25/12/2015. */
 class YearMonthTest extends TemporalTest[YearMonth] {
@@ -135,25 +135,25 @@ class YearMonthTest extends TemporalTest[YearMonth] {
     }
 
     for (ym <- samples) {
-      expectThrows(classOf[DateTimeException], ym.`with`(YEAR, Long.MinValue))
-      expectThrows(classOf[DateTimeException], ym.`with`(YEAR, -1000000000L))
-      expectThrows(classOf[DateTimeException], ym.`with`(YEAR, 1000000000L))
-      expectThrows(classOf[DateTimeException], ym.`with`(YEAR, Long.MaxValue))
+      assertThrows(classOf[DateTimeException], ym.`with`(YEAR, Long.MinValue))
+      assertThrows(classOf[DateTimeException], ym.`with`(YEAR, -1000000000L))
+      assertThrows(classOf[DateTimeException], ym.`with`(YEAR, 1000000000L))
+      assertThrows(classOf[DateTimeException], ym.`with`(YEAR, Long.MaxValue))
 
-      expectThrows(classOf[DateTimeException], ym.`with`(MONTH_OF_YEAR, Long.MinValue))
-      expectThrows(classOf[DateTimeException], ym.`with`(MONTH_OF_YEAR, 0L))
-      expectThrows(classOf[DateTimeException], ym.`with`(MONTH_OF_YEAR, 13L))
-      expectThrows(classOf[DateTimeException], ym.`with`(MONTH_OF_YEAR, Long.MaxValue))
+      assertThrows(classOf[DateTimeException], ym.`with`(MONTH_OF_YEAR, Long.MinValue))
+      assertThrows(classOf[DateTimeException], ym.`with`(MONTH_OF_YEAR, 0L))
+      assertThrows(classOf[DateTimeException], ym.`with`(MONTH_OF_YEAR, 13L))
+      assertThrows(classOf[DateTimeException], ym.`with`(MONTH_OF_YEAR, Long.MaxValue))
 
-      expectThrows(classOf[DateTimeException], ym.`with`(PROLEPTIC_MONTH, Long.MinValue))
-      expectThrows(classOf[DateTimeException], ym.`with`(PROLEPTIC_MONTH, -11999999989L))
-      expectThrows(classOf[DateTimeException], ym.`with`(PROLEPTIC_MONTH, 12000000000L))
-      expectThrows(classOf[DateTimeException], ym.`with`(PROLEPTIC_MONTH, Long.MaxValue))
+      assertThrows(classOf[DateTimeException], ym.`with`(PROLEPTIC_MONTH, Long.MinValue))
+      assertThrows(classOf[DateTimeException], ym.`with`(PROLEPTIC_MONTH, -11999999989L))
+      assertThrows(classOf[DateTimeException], ym.`with`(PROLEPTIC_MONTH, 12000000000L))
+      assertThrows(classOf[DateTimeException], ym.`with`(PROLEPTIC_MONTH, Long.MaxValue))
 
-      expectThrows(classOf[DateTimeException], ym.`with`(ERA, Long.MinValue))
-      expectThrows(classOf[DateTimeException], ym.`with`(ERA, -1L))
-      expectThrows(classOf[DateTimeException], ym.`with`(ERA, -2L))
-      expectThrows(classOf[DateTimeException], ym.`with`(ERA, Long.MaxValue))
+      assertThrows(classOf[DateTimeException], ym.`with`(ERA, Long.MinValue))
+      assertThrows(classOf[DateTimeException], ym.`with`(ERA, -1L))
+      assertThrows(classOf[DateTimeException], ym.`with`(ERA, -2L))
+      assertThrows(classOf[DateTimeException], ym.`with`(ERA, Long.MaxValue))
     }
   }
 
@@ -170,10 +170,10 @@ class YearMonthTest extends TemporalTest[YearMonth] {
     assertEquals(YearMonth.of(0, 12), decFirstAC.withYear(0))
 
     for (ym <- samples) {
-      expectThrows(classOf[DateTimeException], ym.withYear(Int.MinValue))
-      expectThrows(classOf[DateTimeException], ym.withYear(-1000000000))
-      expectThrows(classOf[DateTimeException], ym.withYear(1000000000))
-      expectThrows(classOf[DateTimeException], ym.withYear(Int.MaxValue))
+      assertThrows(classOf[DateTimeException], ym.withYear(Int.MinValue))
+      assertThrows(classOf[DateTimeException], ym.withYear(-1000000000))
+      assertThrows(classOf[DateTimeException], ym.withYear(1000000000))
+      assertThrows(classOf[DateTimeException], ym.withYear(Int.MaxValue))
     }
   }
 
@@ -187,10 +187,10 @@ class YearMonthTest extends TemporalTest[YearMonth] {
     assertEquals(YearMonth.of(1, 1), decFirstAC.withMonth(1))
 
     for (ym <- samples) {
-      expectThrows(classOf[DateTimeException], ym.withMonth(Int.MinValue))
-      expectThrows(classOf[DateTimeException], ym.withMonth(0))
-      expectThrows(classOf[DateTimeException], ym.withMonth(13))
-      expectThrows(classOf[DateTimeException], ym.withMonth(Int.MaxValue))
+      assertThrows(classOf[DateTimeException], ym.withMonth(Int.MinValue))
+      assertThrows(classOf[DateTimeException], ym.withMonth(0))
+      assertThrows(classOf[DateTimeException], ym.withMonth(13))
+      assertThrows(classOf[DateTimeException], ym.withMonth(Int.MaxValue))
     }
   }
 
@@ -217,12 +217,12 @@ class YearMonthTest extends TemporalTest[YearMonth] {
     assertEquals(YearMonth.of(999999999, 1), min.plusYears(1999999998))
     assertEquals(YearMonth.of(-999999999, 12), max.plusYears(-1999999998))
 
-    expectThrows(classOf[DateTimeException], min.plusYears(-1))
-    expectThrows(classOf[DateTimeException], min.plusYears(1999999999))
-    expectThrows(classOf[DateTimeException], max.plusYears(1))
-    expectThrows(classOf[DateTimeException], max.plusYears(-1999999999))
-    expectThrows(classOf[DateTimeException], min.plusYears(Long.MinValue))
-    expectThrows(classOf[DateTimeException], max.plusYears(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], min.plusYears(-1))
+    assertThrows(classOf[DateTimeException], min.plusYears(1999999999))
+    assertThrows(classOf[DateTimeException], max.plusYears(1))
+    assertThrows(classOf[DateTimeException], max.plusYears(-1999999999))
+    assertThrows(classOf[DateTimeException], min.plusYears(Long.MinValue))
+    assertThrows(classOf[DateTimeException], max.plusYears(Long.MaxValue))
   }
 
   @Test def plusMonths(): Unit = {
@@ -238,12 +238,12 @@ class YearMonthTest extends TemporalTest[YearMonth] {
     assertEquals(YearMonth.of(999999999, 12), min.plusMonths(23999999987L))
     assertEquals(YearMonth.of(-999999999, 1), max.plusMonths(-23999999987L))
 
-    expectThrows(classOf[DateTimeException], min.plusMonths(-1))
-    expectThrows(classOf[DateTimeException], min.plusMonths(23999999988L))
-    expectThrows(classOf[DateTimeException], max.plusMonths(-23999999988L))
-    expectThrows(classOf[DateTimeException], max.plusMonths(1))
-    expectThrows(classOf[DateTimeException], min.plusMonths(Long.MinValue))
-    expectThrows(classOf[DateTimeException], max.plusMonths(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], min.plusMonths(-1))
+    assertThrows(classOf[DateTimeException], min.plusMonths(23999999988L))
+    assertThrows(classOf[DateTimeException], max.plusMonths(-23999999988L))
+    assertThrows(classOf[DateTimeException], max.plusMonths(1))
+    assertThrows(classOf[DateTimeException], min.plusMonths(Long.MinValue))
+    assertThrows(classOf[DateTimeException], max.plusMonths(Long.MaxValue))
   }
 
   @Test def minusYears(): Unit = {
@@ -256,12 +256,12 @@ class YearMonthTest extends TemporalTest[YearMonth] {
     assertEquals(YearMonth.of(999999999, 1), min.minusYears(-1999999998))
     assertEquals(YearMonth.of(-999999999, 12), max.minusYears(1999999998))
 
-    expectThrows(classOf[DateTimeException], min.minusYears(1))
-    expectThrows(classOf[DateTimeException], min.minusYears(-1999999999))
-    expectThrows(classOf[DateTimeException], max.minusYears(-1))
-    expectThrows(classOf[DateTimeException], max.minusYears(1999999999))
-    expectThrows(classOf[DateTimeException], min.minusYears(Long.MaxValue))
-    expectThrows(classOf[DateTimeException], max.minusYears(Long.MinValue))
+    assertThrows(classOf[DateTimeException], min.minusYears(1))
+    assertThrows(classOf[DateTimeException], min.minusYears(-1999999999))
+    assertThrows(classOf[DateTimeException], max.minusYears(-1))
+    assertThrows(classOf[DateTimeException], max.minusYears(1999999999))
+    assertThrows(classOf[DateTimeException], min.minusYears(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], max.minusYears(Long.MinValue))
   }
 
   @Test def minusMonths(): Unit = {
@@ -275,12 +275,12 @@ class YearMonthTest extends TemporalTest[YearMonth] {
     assertEquals(YearMonth.of(999999999, 12), min.minusMonths(-23999999987L))
     assertEquals(YearMonth.of(-999999999, 1), max.minusMonths(23999999987L))
 
-    expectThrows(classOf[DateTimeException], min.minusMonths(1))
-    expectThrows(classOf[DateTimeException], min.minusMonths(-23999999988L))
-    expectThrows(classOf[DateTimeException], max.minusMonths(23999999988L))
-    expectThrows(classOf[DateTimeException], max.minusMonths(-1))
-    expectThrows(classOf[DateTimeException], min.minusMonths(Long.MaxValue))
-    expectThrows(classOf[DateTimeException], max.minusMonths(Long.MinValue))
+    assertThrows(classOf[DateTimeException], min.minusMonths(1))
+    assertThrows(classOf[DateTimeException], min.minusMonths(-23999999988L))
+    assertThrows(classOf[DateTimeException], max.minusMonths(23999999988L))
+    assertThrows(classOf[DateTimeException], max.minusMonths(-1))
+    assertThrows(classOf[DateTimeException], min.minusMonths(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], max.minusMonths(Long.MinValue))
   }
 
   @Test def adjustInto(): Unit = {
@@ -336,8 +336,8 @@ class YearMonthTest extends TemporalTest[YearMonth] {
     }
 
     for (ym <- samples) {
-      expectThrows(classOf[DateTimeException], ym.atDay(0))
-      expectThrows(classOf[DateTimeException], ym.atDay(ym.lengthOfMonth() + 1))
+      assertThrows(classOf[DateTimeException], ym.atDay(0))
+      assertThrows(classOf[DateTimeException], ym.atDay(ym.lengthOfMonth() + 1))
     }
   }
 
@@ -416,10 +416,10 @@ class YearMonthTest extends TemporalTest[YearMonth] {
       assertEquals(ym, YearMonth.of(ym.getYear, ym.getMonth))
     }
 
-    expectThrows(classOf[NullPointerException], YearMonth.of(0, null))
+    assertThrows(classOf[NullPointerException], YearMonth.of(0, null))
     for (m <- Month.values()) {
-      expectThrows(classOf[DateTimeException], YearMonth.of(Int.MinValue, m))
-      expectThrows(classOf[DateTimeException], YearMonth.of(Int.MaxValue, m))
+      assertThrows(classOf[DateTimeException], YearMonth.of(Int.MinValue, m))
+      assertThrows(classOf[DateTimeException], YearMonth.of(Int.MaxValue, m))
     }
   }
 
@@ -438,12 +438,12 @@ class YearMonthTest extends TemporalTest[YearMonth] {
       assertEquals(ym, YearMonth.of(ym.getYear, ym.getMonthValue))
     }
 
-    expectThrows(classOf[DateTimeException], YearMonth.of(Int.MinValue, 0))
-    expectThrows(classOf[DateTimeException], YearMonth.of(Int.MaxValue, 0))
-    expectThrows(classOf[DateTimeException], YearMonth.of(min.getYear, 0))
-    expectThrows(classOf[DateTimeException], YearMonth.of(min.getYear, 13))
-    expectThrows(classOf[DateTimeException], YearMonth.of(max.getYear, 0))
-    expectThrows(classOf[DateTimeException], YearMonth.of(max.getYear, 13))
+    assertThrows(classOf[DateTimeException], YearMonth.of(Int.MinValue, 0))
+    assertThrows(classOf[DateTimeException], YearMonth.of(Int.MaxValue, 0))
+    assertThrows(classOf[DateTimeException], YearMonth.of(min.getYear, 0))
+    assertThrows(classOf[DateTimeException], YearMonth.of(min.getYear, 13))
+    assertThrows(classOf[DateTimeException], YearMonth.of(max.getYear, 0))
+    assertThrows(classOf[DateTimeException], YearMonth.of(max.getYear, 13))
   }
 
   @Test def now(): Unit = {
@@ -466,7 +466,7 @@ class YearMonthTest extends TemporalTest[YearMonth] {
     val someDate = LocalDate.of(2015, 1, 1)
     assertEquals(YearMonth.of(2015, 1), YearMonth.from(someDate))
 
-    expectThrows(classOf[DateTimeException], YearMonth.from(Month.JANUARY))
+    assertThrows(classOf[DateTimeException], YearMonth.from(Month.JANUARY))
   }
 
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/YearTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/YearTest.scala
@@ -4,8 +4,8 @@ import java.time._
 import java.time.temporal._
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 import scala.annotation.tailrec
 
@@ -59,7 +59,7 @@ class YearTest extends TemporalTest[Year] {
 
         assertEquals(expected, t.getLong(field))
       } else {
-        expectThrows(classOf[UnsupportedTemporalTypeException], t.getLong(field))
+        assertThrows(classOf[UnsupportedTemporalTypeException], t.getLong(field))
       }
     }
 
@@ -105,22 +105,22 @@ class YearTest extends TemporalTest[Year] {
     assertEquals(Year.of(101), negativeYear.`with`(ERA, 1))
 
     for (t <- samples) {
-      expectThrows(classOf[DateTimeException], t.`with`(YEAR, Long.MinValue))
-      expectThrows(classOf[DateTimeException], t.`with`(YEAR, -1000000000))
-      expectThrows(classOf[DateTimeException], t.`with`(YEAR, 1000000000))
-      expectThrows(classOf[DateTimeException], t.`with`(YEAR, Long.MaxValue))
+      assertThrows(classOf[DateTimeException], t.`with`(YEAR, Long.MinValue))
+      assertThrows(classOf[DateTimeException], t.`with`(YEAR, -1000000000))
+      assertThrows(classOf[DateTimeException], t.`with`(YEAR, 1000000000))
+      assertThrows(classOf[DateTimeException], t.`with`(YEAR, Long.MaxValue))
 
-      expectThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, Long.MinValue))
-      expectThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, -1000000001))
-      expectThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, -1))
-      expectThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, 0))
-      expectThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, 1000000001))
-      expectThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, Long.MaxValue))
+      assertThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, Long.MinValue))
+      assertThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, -1000000001))
+      assertThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, -1))
+      assertThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, 0))
+      assertThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, 1000000001))
+      assertThrows(classOf[DateTimeException], t.`with`(YEAR_OF_ERA, Long.MaxValue))
 
-      expectThrows(classOf[DateTimeException], t.`with`(ERA, Long.MinValue))
-      expectThrows(classOf[DateTimeException], t.`with`(ERA, -1))
-      expectThrows(classOf[DateTimeException], t.`with`(ERA, 2))
-      expectThrows(classOf[DateTimeException], t.`with`(ERA, Long.MaxValue))
+      assertThrows(classOf[DateTimeException], t.`with`(ERA, Long.MinValue))
+      assertThrows(classOf[DateTimeException], t.`with`(ERA, -1))
+      assertThrows(classOf[DateTimeException], t.`with`(ERA, 2))
+      assertThrows(classOf[DateTimeException], t.`with`(ERA, Long.MaxValue))
     }
   }
 
@@ -139,7 +139,7 @@ class YearTest extends TemporalTest[Year] {
     assertEquals(Year.of(1000), lastBCYear.plus(1, MILLENNIA))
     assertEquals(Year.of(-1000), lastBCYear.plus(-1, MILLENNIA))
     assertEquals(firstACYear, lastBCYear.plus(1, ERAS))
-    expectThrows(classOf[DateTimeException], lastBCYear.plus(-1, ERAS))
+    assertThrows(classOf[DateTimeException], lastBCYear.plus(-1, ERAS))
 
     assertEquals(Year.of(11), firstACYear.plus(1, DECADES))
     assertEquals(Year.of(-9), firstACYear.plus(-1, DECADES))
@@ -148,7 +148,7 @@ class YearTest extends TemporalTest[Year] {
     assertEquals(Year.of(1001), firstACYear.plus(1, MILLENNIA))
     assertEquals(Year.of(-999), firstACYear.plus(-1, MILLENNIA))
     assertEquals(lastBCYear, firstACYear.plus(-1, ERAS))
-    expectThrows(classOf[DateTimeException], firstACYear.plus(1, ERAS))
+    assertThrows(classOf[DateTimeException], firstACYear.plus(1, ERAS))
 
     assertEquals(lastBCYear, min.plus(999999999L, YEARS))
     assertEquals(lastBCYear, max.plus(-999999999L, YEARS))
@@ -176,12 +176,12 @@ class YearTest extends TemporalTest[Year] {
     assertEquals(max, min.plusYears(1999999998))
     assertEquals(min, max.plusYears(-1999999998))
 
-    expectThrows(classOf[DateTimeException], min.plusYears(-1))
-    expectThrows(classOf[DateTimeException], min.plusYears(1999999999))
-    expectThrows(classOf[DateTimeException], min.plusYears(Long.MinValue))
-    expectThrows(classOf[DateTimeException], max.plusYears(1))
-    expectThrows(classOf[DateTimeException], max.plusYears(-1999999999))
-    expectThrows(classOf[DateTimeException], max.plusYears(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], min.plusYears(-1))
+    assertThrows(classOf[DateTimeException], min.plusYears(1999999999))
+    assertThrows(classOf[DateTimeException], min.plusYears(Long.MinValue))
+    assertThrows(classOf[DateTimeException], max.plusYears(1))
+    assertThrows(classOf[DateTimeException], max.plusYears(-1999999999))
+    assertThrows(classOf[DateTimeException], max.plusYears(Long.MaxValue))
   }
 
   @Test def minusYears(): Unit = {
@@ -194,12 +194,12 @@ class YearTest extends TemporalTest[Year] {
     assertEquals(max, min.minusYears(-1999999998))
     assertEquals(min, max.minusYears(1999999998))
 
-    expectThrows(classOf[DateTimeException], min.minusYears(1))
-    expectThrows(classOf[DateTimeException], min.minusYears(-1999999999))
-    expectThrows(classOf[DateTimeException], min.minusYears(Long.MinValue))
-    expectThrows(classOf[DateTimeException], max.minusYears(-1))
-    expectThrows(classOf[DateTimeException], max.minusYears(1999999999))
-    expectThrows(classOf[DateTimeException], max.minusYears(Long.MaxValue))
+    assertThrows(classOf[DateTimeException], min.minusYears(1))
+    assertThrows(classOf[DateTimeException], min.minusYears(-1999999999))
+    assertThrows(classOf[DateTimeException], min.minusYears(Long.MinValue))
+    assertThrows(classOf[DateTimeException], max.minusYears(-1))
+    assertThrows(classOf[DateTimeException], max.minusYears(1999999999))
+    assertThrows(classOf[DateTimeException], max.minusYears(Long.MaxValue))
   }
 
   @Test def adjustInto(): Unit = {
@@ -303,18 +303,18 @@ class YearTest extends TemporalTest[Year] {
     for (t <- samples) {
       assertEquals(LocalDate.of(t.getValue, 1, 1), t.atDay(1))
       assertEquals(LocalDate.of(t.getValue, 12, 31), t.atDay(t.length()))
-      expectThrows(classOf[DateTimeException], t.atDay(-1))
+      assertThrows(classOf[DateTimeException], t.atDay(-1))
     }
 
     assertEquals(LocalDate.of(leapYear.getValue, 2, 29), leapYear.atDay(31 + 29))
     assertEquals(LocalDate.of(leapYear.getValue, 3, 1), leapYear.atDay(31 + 30))
     assertEquals(LocalDate.of(leapYear.getValue, 12, 30), leapYear.atDay(365))
     assertEquals(LocalDate.of(leapYear.getValue, 12, 31), leapYear.atDay(366))
-    expectThrows(classOf[DateTimeException], leapYear.atDay(367))
+    assertThrows(classOf[DateTimeException], leapYear.atDay(367))
 
     assertEquals(LocalDate.of(nonLeapYear.getValue, 3, 1), nonLeapYear.atDay(31 + 29))
     assertEquals(LocalDate.of(nonLeapYear.getValue, 12, 31), nonLeapYear.atDay(365))
-    expectThrows(classOf[DateTimeException], nonLeapYear.atDay(366))
+    assertThrows(classOf[DateTimeException], nonLeapYear.atDay(366))
   }
 
   @Test def atMonth(): Unit = {
@@ -324,8 +324,8 @@ class YearTest extends TemporalTest[Year] {
     } {
       assertEquals(YearMonth.of(t.getValue, month.getValue), t.atMonth(month))
       assertEquals(YearMonth.of(t.getValue, month.getValue), t.atMonth(month.getValue))
-      expectThrows(classOf[DateTimeException], t.atMonth(0))
-      expectThrows(classOf[DateTimeException], t.atMonth(13))
+      assertThrows(classOf[DateTimeException], t.atMonth(0))
+      assertThrows(classOf[DateTimeException], t.atMonth(13))
     }
   }
 

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/chrono/ChronoLocalDateTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/chrono/ChronoLocalDateTest.scala
@@ -4,8 +4,8 @@ import java.time.{DateTimeException, LocalTime, LocalDate}
 import java.time.chrono.ChronoLocalDate
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class ChronoLocalDateTest {
   import ChronoLocalDate._
@@ -28,6 +28,6 @@ class ChronoLocalDateTest {
       assertEquals(from(d), d)
 
     for (t <- Seq(LocalTime.MIN, LocalTime.NOON, LocalTime.MAX))
-      expectThrows(classOf[DateTimeException], from(t))
+      assertThrows(classOf[DateTimeException], from(t))
   }
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/chrono/ChronologyTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/chrono/ChronologyTest.scala
@@ -4,15 +4,15 @@ import java.time.DateTimeException
 import java.time.chrono.{IsoChronology, Chronology}
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class ChronologyTest {
   import Chronology._
 
   @Test def test_of(): Unit = {
     assertEquals(of("ISO"), IsoChronology.INSTANCE)
-    expectThrows(classOf[DateTimeException], of(""))
+    assertThrows(classOf[DateTimeException], of(""))
   }
 
   @Test def test_getAvailableChronologies(): Unit = {

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/chrono/IsoChronologyTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/chrono/IsoChronologyTest.scala
@@ -5,8 +5,8 @@ import java.time.chrono.{IsoChronology, IsoEra}
 import java.time.temporal.ChronoField
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.assertEquals
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.javalib.time.DateTimeTestUtil._
 
 class IsoChronologyTest {
@@ -34,7 +34,7 @@ class IsoChronologyTest {
       testDateTime(iso.date(IsoEra.CE, year, month, day))(LocalDate.of(year, month, day))
       testDateTime(iso.date(IsoEra.BCE, 1 - year, month, day))(LocalDate.of(year, month, day))
       testDateTime(iso.date(year, month, day))(LocalDate.of(year, month, day))
-      expectThrows(classOf[ClassCastException], iso.date(null, year, month, day))
+      assertThrows(classOf[ClassCastException], iso.date(null, year, month, day))
     }
   }
 
@@ -51,7 +51,7 @@ class IsoChronologyTest {
       testDateTime(iso.dateYearDay(IsoEra.CE, year, day))(LocalDate.ofYearDay(year, day))
       testDateTime(iso.dateYearDay(IsoEra.BCE, 1 - year, day))(LocalDate.ofYearDay(year, day))
       testDateTime(iso.dateYearDay(year, day))(LocalDate.ofYearDay(year, day))
-      expectThrows(classOf[ClassCastException], iso.dateYearDay(null, year, day))
+      assertThrows(classOf[ClassCastException], iso.dateYearDay(null, year, day))
     }
   }
 
@@ -89,7 +89,7 @@ class IsoChronologyTest {
     assertEquals(IsoEra.CE, iso.eraOf(1))
 
     for (n <- Seq(-Int.MinValue, -1, 2, Int.MaxValue))
-      expectThrows(classOf[DateTimeException], iso.eraOf(n))
+      assertThrows(classOf[DateTimeException], iso.eraOf(n))
   }
 
   @Test def test_eras(): Unit = {

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/chrono/IsoEraTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/chrono/IsoEraTest.scala
@@ -6,8 +6,8 @@ import java.time.temporal.ChronoField
 
 import org.scalajs.testsuite.javalib.time.TemporalAccessorTest
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.{assertEquals, assertArrayEquals}
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class IsoEraTest extends TemporalAccessorTest[IsoEra] {
   import IsoEra._
@@ -42,7 +42,7 @@ class IsoEraTest extends TemporalAccessorTest[IsoEra] {
   @Test def test_valueOf(): Unit = {
     assertEquals(BCE, valueOf("BCE"))
     assertEquals(CE, valueOf("CE"))
-    expectThrows(classOf[IllegalArgumentException], valueOf(""))
+    assertThrows(classOf[IllegalArgumentException], valueOf(""))
   }
 
   @Test def test_of(): Unit = {
@@ -50,6 +50,6 @@ class IsoEraTest extends TemporalAccessorTest[IsoEra] {
     assertEquals(CE, of(1))
 
     for (n <- Seq(Int.MinValue, -1, 2, Int.MaxValue))
-      expectThrows(classOf[DateTimeException], of(n))
+      assertThrows(classOf[DateTimeException], of(n))
   }
 }

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/temporal/ChronoFieldTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/temporal/ChronoFieldTest.scala
@@ -3,8 +3,8 @@ package org.scalajs.testsuite.javalib.time.temporal
 import java.time.temporal.ChronoField
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.{assertEquals, assertArrayEquals}
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class ChronoFieldTest {
   import ChronoField._

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/temporal/ChronoUnitTest.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/javalib/time/temporal/ChronoUnitTest.scala
@@ -3,8 +3,8 @@ package org.scalajs.testsuite.javalib.time.temporal
 import java.time.temporal.ChronoUnit
 
 import org.junit.Test
-import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.junit.Assert.{assertEquals, assertArrayEquals}
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class ChronoUnitTest {
   import ChronoUnit._

--- a/testSuite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
+++ b/testSuite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
@@ -1,56 +1,18 @@
 package org.scalajs.testsuite.utils
 
+import org.junit.Assert
+import org.junit.function.ThrowingRunnable
+
 object AssertThrows {
-  /** Backport implementation of Assert.assertThrows to be used until JUnit 4.13 is
-   *  released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private def assertThrowsBackport(expectedThrowable: Class[_ <: Throwable],
-      runnable: ThrowingRunnable): Unit = {
-    expectThrowsBackport(expectedThrowable, runnable)
+  def assertThrows[T <: Throwable, U](
+      expectedThrowable: Class[T],
+      code: => U
+  ): T = {
+    Assert.assertThrows(
+      expectedThrowable,
+      new ThrowingRunnable {
+        def run(): Unit = code
+      }
+    )
   }
-
-  /** Backport implementation of Assert.expectThrows to be used until JUnit 4.13 is
-   *  released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private def expectThrowsBackport[T <: Throwable](expectedThrowable: Class[T],
-      runnable: ThrowingRunnable): T = {
-    try {
-      runnable.run()
-      val message =
-        s"expected ${expectedThrowable.getSimpleName} to be thrown," +
-          " but nothing was thrown"
-      throw new AssertionError(message)
-    } catch {
-      case actualThrown: Throwable =>
-        if (expectedThrowable.isInstance(actualThrown)) {
-          actualThrown.asInstanceOf[T]
-        } else {
-          val mismatchMessage = "unexpected exception type thrown;" +
-            expectedThrowable.getSimpleName + " " + actualThrown.getClass.getSimpleName
-
-          val assertionError = new AssertionError(mismatchMessage)
-          assertionError.initCause(actualThrown)
-          throw assertionError
-        }
-    }
-  }
-
-  /** Backport implementation of Assert.ThrowingRunnable to be used until
-   *  JUnit 4.13 is released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private trait ThrowingRunnable {
-    def run(): Unit
-  }
-
-  private def throwingRunnable(code: => Unit): ThrowingRunnable = {
-    new ThrowingRunnable {
-      def run(): Unit = code
-    }
-  }
-
-  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): Unit =
-    assertThrowsBackport(expectedThrowable, throwingRunnable(code.asInstanceOf[Unit]))
-
-  def expectThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): T =
-    expectThrowsBackport(expectedThrowable, throwingRunnable(code.asInstanceOf[Unit]))
 }


### PR DESCRIPTION
- Use setup-java
- Update versions missed via Scala Steward
- Update assertThrows and change tests to use
- Change all test imports to avoid ambiguity