### PR TITLE
Drop Scala 2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The library is an incomplete implementation of Java's `java.time`. Please refer 
 
 
 ## Other choices
-This project is ready today and cross compiled for all current Scala versions on Scala.js and Scala Native.
+This project is ready today and cross compiled for all current Scala versions on Scala.js and Scala Native. This project was initial started because no alternative existed to support `sconfig`. `sconfig` uses provided so you are not locked into a `java.time` provider.
 
 The following projects could be considered as alternatives, the second one for Scala.js only:
 
@@ -25,7 +25,6 @@ The following projects could be considered as alternatives, the second one for S
 
 | Scala Version          | Scala.js (1.x)        | Native (0.4.x) |
 | ---------------------- | :-------------------: | :------------: |
-| 2.11.x                 |          ✅           |       ✅       |
 | 2.12.x                 |          ✅           |       ✅       |
 | 2.13.x                 |          ✅           |       ✅       |
 | 3.x.x                  |          ✅           |       ✅       |

--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
-val scala211 = "2.11.12"
+
 val scala212 = "2.12.17"
 val scala213 = "2.13.10"
 val scala300 = "3.2.1"
 
-val versionsBase   = Seq(scala212, scala211, scala213)
+val versionsBase   = Seq(scala212, scala213)
 val versionsJVM    = versionsBase :+ scala300
 val versionsJS     = versionsJVM
 val versionsNative = versionsJVM
@@ -45,7 +45,6 @@ inThisBuild(
 val depSettings = Def.setting {
   CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((3, _))  => Nil
-    case Some((2, 11)) => Seq("-target:jvm-1.8")
     case Some((2, 12)) => Seq("-target:jvm-1.8", "-Xsource:3")
     case Some((2, 13)) => Seq("-Xsource:3")
     case _             => Nil


### PR DESCRIPTION
To support the latest version 1.13.0 of Scala.js which dropped Scala 2.11