### PR TITLE
Remove Java 8 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        java: [ '8', '11', '17' ]
+        java: [ '11', '17' ]
     name: Test using Java ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Upgrading to sbt 1.9.8 does not work in CI. It is still possible to use Java 8 but Java 17 is recommended.
See https://github.com/sbt/sbt/issues/7463